### PR TITLE
Updated module-info.java to use com.azure.core.v2 if com.azure.core is used.

### DIFF
--- a/rewrite-java-core/src/main/resources/META-INF/rewrite/rewrite.yml
+++ b/rewrite-java-core/src/main/resources/META-INF/rewrite/rewrite.yml
@@ -7,3 +7,11 @@ recipeList:
       oldPackageName: com.azure
       newPackageName: io.clientcore
       recursive: true
+  - org.openrewrite.text.FindAndReplace:
+      find: 'requires com.azure.core'
+      replace: 'requires com.azure.core.v2'
+      filePattern: '**/module-info.java'
+  - org.openrewrite.text.FindAndReplace:
+      find: 'requires transitive com.azure.core'
+      replace: 'requires transitive com.azure.core.v2'
+      filePattern: '**/module-info.java'


### PR DESCRIPTION
**Added two recipes to rewrite.yml:** 

- Recipe to change `requires com.azure.core` to `requires com.azure.core.v2` in `module-info.java`
- Recipe to change `requires transitive com.azure.core` to `requires transitive com.azure.core.v2` in `module-info.java`

OpenRewrite's FindAndReplace recipe for changing plain text was used due to OpenRewrite's lack of support for converting Java module declarations to LSTs.

Fixes #6 