### PR TITLE
Updated module-info recipe

### DIFF
--- a/rewrite-java-core/src/main/resources/META-INF/rewrite/rewrite.yml
+++ b/rewrite-java-core/src/main/resources/META-INF/rewrite/rewrite.yml
@@ -8,10 +8,7 @@ recipeList:
       newPackageName: io.clientcore
       recursive: true
   - org.openrewrite.text.FindAndReplace:
-      find: 'requires com.azure.core'
-      replace: 'requires com.azure.core.v2'
-      filePattern: '**/module-info.java'
-  - org.openrewrite.text.FindAndReplace:
-      find: 'requires transitive com.azure.core'
-      replace: 'requires transitive com.azure.core.v2'
+      regex: true
+      find: 'requires\s+(transitive\s+)?com\.azure\.core(?!\.v2)'
+      replace: 'requires $1com.azure.core.v2'
       filePattern: '**/module-info.java'

--- a/rewrite-java-core/src/main/resources/META-INF/rewrite/rewrite.yml
+++ b/rewrite-java-core/src/main/resources/META-INF/rewrite/rewrite.yml
@@ -3,10 +3,6 @@ name: com.azure.rewrite.java.core.MigrateAzureCoreSamplesToAzureCoreV2
 displayName: Migrate azure-core samples to azure-core-v2
 description: This recipe migrates the samples in azure-core to azure-core-v2
 recipeList:
-  - org.openrewrite.java.ChangePackage:
-      oldPackageName: com.azure
-      newPackageName: io.clientcore
-      recursive: true
   - org.openrewrite.text.FindAndReplace:
       regex: true
       find: 'requires\s+(transitive\s+)?com\.azure\.core(?!\.v2)'


### PR DESCRIPTION
**Changes in this PR:**
- Combined the two module-info recipes into one by using regex
- Ensured idempotency by checking if `requires com.azure.core.v2` or `requires transitive com.azure.core.v2` already exists using regex
- Removed example recipe