### PR TITLE
Added basic recipe for Issue4 add http prefix to retryOptions in Builder. Patched build error in rewrite tests

### DIFF
--- a/rewrite-java-core/src/main/resources/META-INF/rewrite/rewrite.yml
+++ b/rewrite-java-core/src/main/resources/META-INF/rewrite/rewrite.yml
@@ -9,3 +9,8 @@ recipeList:
       find: 'requires\s+(transitive\s+)?com\.azure\.core(?!\.v2)'
       replace: 'requires $1com.azure.core.v2'
       filePattern: '**/module-info.java'
+  # Recipe to add http prefix to retryOptions in local class TextTranslationClientBuilder ONLY
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: com.azure.ai.translation.text.TextTranslationClientBuilder retryOptions(..)
+      newMethodName: httpRetryOptions
+      matchOverrides: true

--- a/rewrite-java-core/src/test/java/ModuleInfoTest.java
+++ b/rewrite-java-core/src/test/java/ModuleInfoTest.java
@@ -19,7 +19,7 @@ public class ModuleInfoTest implements RewriteTest {
     public void defaults(RecipeSpec spec) {
         spec.recipe(new FindAndReplace("requires\\s+(transitive\\s+)?com\\.azure\\.core(?!\\.v2)",
                 "requires $1com.azure.core.v2",
-                true,false,null,null,null));
+                true,false,null,null,null,null));
     }
 
     /**


### PR DESCRIPTION

**List of changes in this PR:**

- Added recipe for Issue 4. Add http prefix to Builder API retryOptions.
- Patched build error when running clean install. In ModuleInfoTest FindAndReplace was missing a parameter. I added a null.

NOTE: http prefix added to inherited method retryOptions in TextTranslationClientBuilder ONLY.
Not a complete solution!