### PR TITLE
Fixed bug where FindAndReplace would not work for module-info.java

### DIFF
--- a/rewrite-sample/pom.xml
+++ b/rewrite-sample/pom.xml
@@ -36,7 +36,7 @@
                         <artifactId>rewrite-java-core</artifactId>
                         <version>1.0.0</version>
                     </dependency>
-                    <dependency>
+                    <!-- <dependency>
                         <groupId>org.openrewrite</groupId>
                         <artifactId>rewrite-java</artifactId>
                         <version>8.32.1</version>
@@ -53,7 +53,7 @@
                         <artifactId>rewrite-maven</artifactId>
                         <version>8.32.1</version>
                         <scope>compile</scope>
-                    </dependency>
+                    </dependency>!-->
 
                 </dependencies>
             </plugin>


### PR DESCRIPTION
Changes in this PR:
- Reverted OpenRewrite dependency to allow FindAndReplace recipe to modify dependencies in module-info.java.