### PR TITLE
Added RequestOptions recipe, unit tests and fixed a few bugs

### DIFF
--- a/rewrite-java-core/src/main/java/com/azure/recipes/v2recipes/ContextRecipe.java
+++ b/rewrite-java-core/src/main/java/com/azure/recipes/v2recipes/ContextRecipe.java
@@ -8,7 +8,7 @@ import org.openrewrite.java.tree.TypeTree;
 
 /**
  * ContextRecipe changes all instances of Context.NONE (from azure core v1) to Context.none() (from azure core v2).
- * Note: This recipe does not change the import statement for Context to work with new azure libraries.
+ * This recipe also updates the import statements for the aforementioned class.
  * @author Ali Soltanian Fard Jahromi
  */
 public class ContextRecipe extends Recipe {

--- a/rewrite-java-core/src/main/java/com/azure/recipes/v2recipes/RequestOptionsRecipe.java
+++ b/rewrite-java-core/src/main/java/com/azure/recipes/v2recipes/RequestOptionsRecipe.java
@@ -1,0 +1,57 @@
+package com.azure.recipes.v2recipes;
+
+import org.jetbrains.annotations.NotNull;
+import org.openrewrite.*;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.TypeTree;
+
+/**
+ * RequestOptionsRecipe changes all instances of com.azure.core.http.rest.RequestOptions (from azure core v1)
+ * to io.clientcore.core.http.models.RequestOptions (from azure core v2).
+ * @author Ali Soltanian Fard Jahromi
+ */
+public class RequestOptionsRecipe extends Recipe {
+    /**
+     * Method to return a simple short description of RequestOptionsRecipe
+     * @return A simple short description/name of the recipe
+     */
+    @Override
+    public @NotNull String getDisplayName() {
+        return "Update RequestOptions";
+    }
+    /**
+     * Method to return a description of RequestOptionsRecipe
+     * @return A short description of the recipe
+     */
+    @Override
+    public @NotNull String getDescription() {
+        return "This recipe changes all instances of com.azure.core.http.rest.RequestOptions " +
+                "to io.clientcore.core.http.models.RequestOptions.";
+    }
+    /**
+     * Method to return the visitor that visits the RequestOptions identifier
+     * @return A TreeVisitor to visit the RequestOptions identifier and update it to new library
+     */
+    @Override
+    public @NotNull TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new ChangeStaticFieldToMethodVisitor();
+    }
+    /**
+     * Visitor to change com.azure.core.http.rest.RequestOptions to io.clientcore.core.http.models.RequestOptions
+     */
+    private static class ChangeStaticFieldToMethodVisitor extends JavaIsoVisitor<ExecutionContext> {
+        /**
+         * Method to change com.azure.core.http.rest.RequestOptions to io.clientcore.core.http.models.RequestOptions
+         */
+        @Override
+        public J.@NotNull FieldAccess visitFieldAccess(J.@NotNull FieldAccess fieldAccess, @NotNull ExecutionContext ctx) {
+            J.FieldAccess fa = super.visitFieldAccess(fieldAccess, ctx);
+            String fullyQualified = fa.getTarget() + "." + fa.getSimpleName();
+            if (fullyQualified.equals("com.azure.core.http.rest.RequestOptions")) {
+                return TypeTree.build(" io.clientcore.core.http.models.RequestOptions");
+            }
+            return fa;
+        }
+    }
+}

--- a/rewrite-java-core/src/test/java/ModuleInfoTest.java
+++ b/rewrite-java-core/src/test/java/ModuleInfoTest.java
@@ -60,6 +60,7 @@ public class ModuleInfoTest implements RewriteTest {
     /**
      * This test method is used to make sure no changes are applied if module-info already uses transitive com.azure.core.v2
      */
+    @Test
     void testTransitiveNoMatch() {
         rewriteRun(
                 // Define input and expected output

--- a/rewrite-java-core/src/test/java/RequestOptionsTest.java
+++ b/rewrite-java-core/src/test/java/RequestOptionsTest.java
@@ -1,0 +1,69 @@
+import com.azure.recipes.v2recipes.RequestOptionsRecipe;
+import org.intellij.lang.annotations.Language;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+/**
+ * RequestOptionsTest is used to test out the recipe that converts com.azure.core.http.rest.RequestOptions
+ * to io.clientcore.core.http.models.RequestOptions.
+ * @author Ali Soltanian Fard Jahromi
+ */
+class RequestOptionsTest implements RewriteTest {
+
+    /**
+     * This method sets which recipe should be used for testing
+     * @param spec stores settings for testing environment; e.g. which recipes to use for testing
+     */
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new RequestOptionsRecipe());
+    }
+
+    /**
+     * This test method is used to make sure that the import statement for RequestOptions is changed
+     */
+    @Test
+    void testImports() {
+        @Language("java") String before = "import com.azure.core.http.rest.RequestOptions;";
+        before += "\npublic class Testing {";
+        before += "\n  public Testing(){";
+        before += "\n    System.out.println('h');";
+        before += "\n  }";
+        before += "\n}";
+
+        @Language("java") String after = "import io.clientcore.core.http.models.RequestOptions;";
+        after += "\npublic class Testing {";
+        after += "\n  public Testing(){";
+        after += "\n    System.out.println('h');";
+        after += "\n  }";
+        after += "\n}";
+        rewriteRun(
+                java(before,after)
+        );
+    }
+    /**
+     * This test method is used to make sure that the class type for RequestOptions is updated
+     */
+    @Test
+    void testInit() {
+        @Language("java") String before = "import com.azure.core.http.rest.RequestOptions;";
+        before += "\npublic class Testing {";
+        before += "\n  public Testing(){";
+        before += "\n    com.azure.core.http.rest.RequestOptions r = new RequestOptions();";
+        before += "\n  }";
+        before += "\n}";
+
+        @Language("java") String after = "import io.clientcore.core.http.models.RequestOptions;";
+        after += "\npublic class Testing {";
+        after += "\n  public Testing(){";
+        after += "\n     io.clientcore.core.http.models.RequestOptions r = new RequestOptions();";
+        after += "\n  }";
+        after += "\n}";
+        rewriteRun(
+                java(before,after)
+        );
+    }
+}

--- a/rewrite-sample/pom.xml
+++ b/rewrite-sample/pom.xml
@@ -29,6 +29,7 @@
                         <recipe>com.azure.rewrite.java.core.MigrateAzureCoreSamplesToAzureCoreV2</recipe>
                         <recipe>com.azure.recipes.v2recipes.HttpPrefixRecipe</recipe>
                         <recipe>com.azure.recipes.v2recipes.ContextRecipe</recipe>
+                        <recipe>com.azure.recipes.v2recipes.RequestOptionsRecipe</recipe>
                     </activeRecipes>
                 </configuration>
                 <dependencies>


### PR DESCRIPTION
**Changes in this PR:**
- Added RequestOptionsRecipe to change `com.azure.core.http.rest.RequestOptions` to `io.clientcore.core.http.models.RequestOptions`
- Added unit tests for RequestOptionsRecipe
- Added missing `@Test` annotation to unit test in ModuleInfoTest

closes #20 