### PR TITLE
Fix io.clientcore.core references

### DIFF
--- a/rewrite-java-core/src/main/java/com/azure/recipes/v2recipes/ContextRecipe.java
+++ b/rewrite-java-core/src/main/java/com/azure/recipes/v2recipes/ContextRecipe.java
@@ -27,7 +27,7 @@ public class ContextRecipe extends Recipe {
     @Override
     public @NotNull String getDescription() {
         return "This recipe changes any calls to Context.NONE to Context.none().\n" +
-                "It also changes the import statement of com.azure.core.util.Context to io.clientcore.util.Context.";
+                "It also changes the import statement of com.azure.core.util.Context to io.clientcore.core.util.Context.";
     }
     /**
      * Method to return the visitor that visits the Context.NONE identifier
@@ -42,7 +42,7 @@ public class ContextRecipe extends Recipe {
      */
     private static class ChangeStaticFieldToMethodVisitor extends JavaIsoVisitor<ExecutionContext> {
         /**
-         * Method to change com.azure.core.util.Context to io.clientcore.util.Context
+         * Method to change com.azure.core.util.Context to io.clientcore.core.util.Context
          */
         @Override
         public J.@NotNull FieldAccess visitFieldAccess(J.@NotNull FieldAccess fieldAccess, @NotNull ExecutionContext ctx) {
@@ -50,7 +50,7 @@ public class ContextRecipe extends Recipe {
             String fullyQualified = fa.getTarget() + "." + fa.getSimpleName();
             //System.out.println(fullyQualified);
             if (fullyQualified.equals("com.azure.core.util.Context")) {
-               return TypeTree.build(" io.clientcore.util.Context");
+               return TypeTree.build(" io.clientcore.core.util.Context");
             }
             if (fullyQualified.equals("Context.NONE")){
                 return TypeTree.build("Context.none()");

--- a/rewrite-java-core/src/main/resources/META-INF/rewrite/rewrite.yml
+++ b/rewrite-java-core/src/main/resources/META-INF/rewrite/rewrite.yml
@@ -15,12 +15,12 @@ recipeList:
   # to io.clientcore.core.http.models.RequestOptions
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: com.azure.core.http.rest.RequestOptions
-      newFullyQualifiedTypeName: io.clientcore.http.models.RequestOptions
+      newFullyQualifiedTypeName: io.clientcore.core.http.models.RequestOptions
   # Recipe that changes all instances of com.azure.core.http.policy.RetryOptions
   # to io.clientcore.http.models.HttpRetryOptions
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: com.azure.core.http.policy.RetryOptions
-      newFullyQualifiedTypeName: io.clientcore.http.models.HttpRetryOptions
+      newFullyQualifiedTypeName: io.clientcore.core.http.models.HttpRetryOptions
   # Recipes to migrate implementations of com.azure.core.client.traits.HttpTrait
   # to io.clientcore.core.models.traits.HttpTrait
   # Add http prefix to renamed methods

--- a/rewrite-java-core/src/test/java/ContextTest.java
+++ b/rewrite-java-core/src/test/java/ContextTest.java
@@ -32,7 +32,7 @@ class ContextTest implements RewriteTest {
         before += "\n  public Testing(){}";
         before += "\n}";
 
-        @Language("java") String after = "import io.clientcore.util.Context;";
+        @Language("java") String after = "import io.clientcore.core.util.Context;";
         after += "\npublic class Testing {";
         after += "\n  public Testing(){}";
         after += "\n}";

--- a/rewrite-java-core/src/test/java/RequestOptionsTest.java
+++ b/rewrite-java-core/src/test/java/RequestOptionsTest.java
@@ -8,7 +8,7 @@ import static org.openrewrite.java.Assertions.java;
 
 /**
  * RequestOptionsTest is used to test out the recipe that converts com.azure.core.http.rest.RequestOptions
- * to io.clientcore.core.core.http.models.RequestOptions.
+ * to io.clientcore.core.http.models.RequestOptions.
  * @author Ali Soltanian Fard Jahromi
  */
 class RequestOptionsTest implements RewriteTest {

--- a/rewrite-java-core/src/test/java/RequestOptionsTest.java
+++ b/rewrite-java-core/src/test/java/RequestOptionsTest.java
@@ -8,7 +8,7 @@ import static org.openrewrite.java.Assertions.java;
 
 /**
  * RequestOptionsTest is used to test out the recipe that converts com.azure.core.http.rest.RequestOptions
- * to io.clientcore.core.http.models.RequestOptions.
+ * to io.clientcore.core.core.http.models.RequestOptions.
  * @author Ali Soltanian Fard Jahromi
  */
 class RequestOptionsTest implements RewriteTest {
@@ -20,7 +20,7 @@ class RequestOptionsTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec.recipe(new ChangeType("com.azure.core.http.rest.RequestOptions",
-                "io.clientcore.http.models.RequestOptions", null));
+                "io.clientcore.core.http.models.RequestOptions", null));
     }
 
     /**
@@ -35,10 +35,10 @@ class RequestOptionsTest implements RewriteTest {
         before += "\n  }";
         before += "\n}";
 
-        @Language("java") String after = "import io.clientcore.http.models.RequestOptions;";
+        @Language("java") String after = "import io.clientcore.core.http.models.RequestOptions;";
         after += "\n\npublic class Testing {";
         after += "\n  public Testing(){";
-        after += "\n    io.clientcore.http.models.RequestOptions r = new RequestOptions();";
+        after += "\n    io.clientcore.core.http.models.RequestOptions r = new RequestOptions();";
         after += "\n  }";
         after += "\n}";
         rewriteRun(


### PR DESCRIPTION
This PR fixes a typo in the references to the io.clientcore.core package. It was referred to as "io.clientcore" instead of "io.clientcore.core" in some of our recipes. The issue has now been addressed by this PR.