### PR TITLE
Add annotation type recipes and unit tests

### DIFF
--- a/rewrite-java-core/src/main/resources/META-INF/rewrite/rewrite.yml
+++ b/rewrite-java-core/src/main/resources/META-INF/rewrite/rewrite.yml
@@ -25,55 +25,85 @@ recipeList:
 
   # Recipe that changes all instances of com.azure.core.annotation.HostParam
   # to io.clientcore.core.http.annotation.HostParam
+  # TODO: Add unit test for this recipe
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: com.azure.core.annotation.HostParam
       newFullyQualifiedTypeName: io.clientcore.core.http.annotation.HostParam
 
   # Recipe that changes all instances of com.azure.core.annotation.HeaderParam
   # to io.clientcore.core.http.annotation.HeaderParam
+  # TODO: Add unit test for this recipe
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: com.azure.core.annotation.HeaderParam
       newFullyQualifiedTypeName: io.clientcore.core.http.annotation.HeaderParam
 
   # Recipe that changes all instances of com.azure.core.annotation.BodyParam
   # to io.clientcore.core.http.annotation.BodyParam
+  # TODO: Add unit test for this recipe
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: com.azure.core.annotation.BodyParam
       newFullyQualifiedTypeName: io.clientcore.core.http.annotation.BodyParam
 
   # Recipe that changes all instances of com.azure.core.annotation.QueryParam
   # to io.clientcore.core.http.annotation.QueryParam
+  # TODO: Add unit test for this recipe
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: com.azure.core.annotation.QueryParam
       newFullyQualifiedTypeName: io.clientcore.core.http.annotation.QueryParam
 
   # Recipe that changes all instances of com.azure.core.annotation.ServiceClient
   # to com.azure.core.v2.annotation.ServiceClient
+  # TODO: Add unit test for this recipe
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: com.azure.core.annotation.ServiceClient
       newFullyQualifiedTypeName: com.azure.core.v2.annotation.ServiceClient
 
   # Recipe that changes all instances of com.azure.core.annotation.ServiceClientBuilder
   # to com.azure.core.v2.annotation.ServiceClientBuilder
+  # TODO: Add unit test for this recipe
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: com.azure.core.annotation.ServiceClientBuilder
       newFullyQualifiedTypeName: com.azure.core.v2.annotation.ServiceClientBuilder
 
   # Recipe that changes all instances of com.azure.core.annotation.ServiceInterface
   # to io.clientcore.core.annotation.ServiceInterface
+  # TODO: Add unit test for this recipe
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: com.azure.core.annotation.ServiceInterface
       newFullyQualifiedTypeName: io.clientcore.core.annotation.ServiceInterface
 
   # Recipe that changes all instances of com.azure.core.annotation.ServiceMethod
   # to com.azure.core.v2.annotation.ServiceMethod
+  # TODO: Add unit test for this recipe
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: com.azure.core.annotation.ServiceMethod
       newFullyQualifiedTypeName: com.azure.core.v2.annotation.ServiceMethod
 
+  # Recipe that changes all instances of com.azure.core.annotation.Generated
+  # to com.azure.core.v2.annotation.Generated
+  # TODO: Add unit test for this recipe
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: com.azure.core.annotation.Generated
+      newFullyQualifiedTypeName: com.azure.core.v2.annotation.Generated
+
+  # Recipe that changes all instances of com.azure.core.annotation.Immutable
+  # to com.azure.core.v2.annotation.Immutable
+  # TODO: Add unit test for this recipe
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: com.azure.core.annotation.Immutable
+      newFullyQualifiedTypeName: com.azure.core.v2.annotation.Immutable
+
+  # Recipe that changes all instances of com.azure.core.annotation.ReturnType
+  # to com.azure.core.v2.annotation.ReturnType
+  # TODO: Add unit test for this recipe
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: com.azure.core.annotation.ReturnType
+      newFullyQualifiedTypeName: com.azure.core.v2.annotation.ReturnType
+
   # Recipes to migrate implementations of com.azure.core.client.traits.HttpTrait
   # to io.clientcore.core.models.traits.HttpTrait
   # Add http prefix to renamed methods
+  # TODO: Add unit tests for the below recipes
   - org.openrewrite.java.ChangeMethodName:
       methodPattern: com.azure.core.client.traits.HttpTrait retryOptions(..)
       newMethodName: httpRetryOptions

--- a/rewrite-java-core/src/main/resources/META-INF/rewrite/rewrite.yml
+++ b/rewrite-java-core/src/main/resources/META-INF/rewrite/rewrite.yml
@@ -25,28 +25,24 @@ recipeList:
 
   # Recipe that changes all instances of com.azure.core.annotation.HostParam
   # to io.clientcore.core.http.annotation.HostParam
-  # TODO: Add unit test for this recipe
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: com.azure.core.annotation.HostParam
       newFullyQualifiedTypeName: io.clientcore.core.http.annotation.HostParam
 
   # Recipe that changes all instances of com.azure.core.annotation.HeaderParam
   # to io.clientcore.core.http.annotation.HeaderParam
-  # TODO: Add unit test for this recipe
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: com.azure.core.annotation.HeaderParam
       newFullyQualifiedTypeName: io.clientcore.core.http.annotation.HeaderParam
 
   # Recipe that changes all instances of com.azure.core.annotation.BodyParam
   # to io.clientcore.core.http.annotation.BodyParam
-  # TODO: Add unit test for this recipe
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: com.azure.core.annotation.BodyParam
       newFullyQualifiedTypeName: io.clientcore.core.http.annotation.BodyParam
 
   # Recipe that changes all instances of com.azure.core.annotation.QueryParam
   # to io.clientcore.core.http.annotation.QueryParam
-  # TODO: Add unit test for this recipe
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: com.azure.core.annotation.QueryParam
       newFullyQualifiedTypeName: io.clientcore.core.http.annotation.QueryParam

--- a/rewrite-java-core/src/test/java/CredentialTest.java
+++ b/rewrite-java-core/src/test/java/CredentialTest.java
@@ -1,0 +1,48 @@
+import org.intellij.lang.annotations.Language;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.ChangePackage;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+/**
+ * CredentialTest is used to test out the recipe that changes the package name com.azure.core.credential
+ * to io.clientcore.core.credential.
+ * @author Ali Soltanian Fard Jahromi
+ */
+class CredentialTest implements RewriteTest {
+
+    /**
+     * This method sets which recipe should be used for testing
+     * @param spec stores settings for testing environment; e.g. which recipes to use for testing
+     */
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new ChangePackage("com.azure.core.credential",
+                "io.clientcore.core.credential", null));
+    }
+
+    /**
+     * This test method is used to make sure that the package com.azure.core.credential is changed
+     */
+    @Test
+    void testPackageNameChange() {
+        @Language("java") String before = "import com.azure.core.credential.KeyCredential;";
+        before += "\npublic class Testing {";
+        before += "\n  public Testing(){";
+        before += "\n    com.azure.core.credential.KeyCredential kc = new KeyCredential(\"<api-key>\");";
+        before += "\n  }";
+        before += "\n}";
+
+        @Language("java") String after = "import io.clientcore.core.credential.KeyCredential;";
+        after += "\npublic class Testing {";
+        after += "\n  public Testing(){";
+        after += "\n    io.clientcore.core.credential.KeyCredential kc = new KeyCredential(\"<api-key>\");";
+        after += "\n  }";
+        after += "\n}";
+        rewriteRun(
+                java(before,after)
+        );
+    }
+}

--- a/rewrite-java-core/src/test/java/ParamAnnotationTest.java
+++ b/rewrite-java-core/src/test/java/ParamAnnotationTest.java
@@ -1,0 +1,69 @@
+import org.intellij.lang.annotations.Language;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.ChangeType;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+/**
+ * ParamAnnotationTest is used to test out the recipe that changes the type for the @HostParam, @HeaderParam
+ * , @BodyParam and @QueryParam annotations.
+ * @author Ali Soltanian Fard Jahromi
+ */
+class ParamAnnotationTest implements RewriteTest {
+    /**
+     * This method sets which recipe should be used for testing
+     * @param spec stores settings for testing environment; e.g. which recipes to use for testing
+     */
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipes(new ChangeType("com.azure.core.annotation.HostParam",
+                "io.clientcore.core.http.annotation.HostParam", null),
+
+                new ChangeType("com.azure.core.annotation.HeaderParam",
+                        "io.clientcore.core.http.annotation.HeaderParam", null),
+
+                new ChangeType("com.azure.core.annotation.QueryParam",
+                        "io.clientcore.core.http.annotation.QueryParam", null),
+
+                new ChangeType("com.azure.core.annotation.BodyParam",
+                        "io.clientcore.core.http.annotation.BodyParam", null));
+    }
+
+    /**
+     * This test method is used to make sure that the annotation types are changed correctly
+     */
+    @Test
+    void testParam() {
+        @Language("java") String before = "import com.azure.core.annotation.HostParam;" +
+                "\nimport com.azure.core.annotation.BodyParam;" +
+                "\nimport com.azure.core.util.Context;" +
+                "\nimport com.azure.core.util.BinaryData;" +
+                "\nimport com.azure.core.annotation.QueryParam;" +
+                "\nimport com.azure.core.annotation.HeaderParam;" +
+                "\nimport com.azure.core.http.rest.RequestOptions;";
+        before += "\npublic class Testing {";
+        before += "\n  ";
+        before += "\n    Response<BinaryData> getSupportedLanguagesSync(@BodyParam(\"application/json\") BinaryData body, @HostParam(\"Endpoint\") String endpoint, @QueryParam(\"api-version\") String apiVersion, @HeaderParam(\"accept\") String accept, RequestOptions requestOptions, Context context);";
+        before += "\n  ";
+        before += "\n}";
+
+        @Language("java") String after =
+                "\nimport com.azure.core.util.Context;" +
+                "\nimport io.clientcore.core.http.annotation.BodyParam;" +
+                "\nimport io.clientcore.core.http.annotation.HeaderParam;" +
+                "\nimport io.clientcore.core.http.annotation.HostParam;" +
+                "\nimport io.clientcore.core.http.annotation.QueryParam;" +
+                "\nimport com.azure.core.util.BinaryData;" +
+                "\nimport com.azure.core.http.rest.RequestOptions;";
+        after += "\n\npublic class Testing {";
+        after += "\n  ";
+        after += "\n    Response<BinaryData> getSupportedLanguagesSync(@BodyParam(\"application/json\") BinaryData body, @HostParam(\"Endpoint\") String endpoint, @QueryParam(\"api-version\") String apiVersion, @HeaderParam(\"accept\") String accept, RequestOptions requestOptions, Context context);";
+        after += "\n  ";
+        after += "\n}";
+        rewriteRun(
+                java(before,after)
+        );
+    }
+}


### PR DESCRIPTION
Changes in this PR:
- Added recipes that change the miscellaneous annotation types @ Generated, @ Immutable, and @ ReturnType
- Added unit test for recipe that changes `com.azure.core.credential` to `io.clientcore.core.credential` package name
- Added unit test for recipes that change the @--Param annotation types
- Added TODO notes for recipes that need unit tests

resolves #35 