### PR TITLE
Unit tests backlog

### DIFF
--- a/rewrite-java-core/src/main/resources/META-INF/rewrite/rewrite.yml
+++ b/rewrite-java-core/src/main/resources/META-INF/rewrite/rewrite.yml
@@ -49,49 +49,42 @@ recipeList:
 
   # Recipe that changes all instances of com.azure.core.annotation.ServiceClient
   # to com.azure.core.v2.annotation.ServiceClient
-  # TODO: Add unit test for this recipe
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: com.azure.core.annotation.ServiceClient
       newFullyQualifiedTypeName: com.azure.core.v2.annotation.ServiceClient
 
   # Recipe that changes all instances of com.azure.core.annotation.ServiceClientBuilder
   # to com.azure.core.v2.annotation.ServiceClientBuilder
-  # TODO: Add unit test for this recipe
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: com.azure.core.annotation.ServiceClientBuilder
       newFullyQualifiedTypeName: com.azure.core.v2.annotation.ServiceClientBuilder
 
   # Recipe that changes all instances of com.azure.core.annotation.ServiceInterface
   # to io.clientcore.core.annotation.ServiceInterface
-  # TODO: Add unit test for this recipe
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: com.azure.core.annotation.ServiceInterface
       newFullyQualifiedTypeName: io.clientcore.core.annotation.ServiceInterface
 
   # Recipe that changes all instances of com.azure.core.annotation.ServiceMethod
   # to com.azure.core.v2.annotation.ServiceMethod
-  # TODO: Add unit test for this recipe
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: com.azure.core.annotation.ServiceMethod
       newFullyQualifiedTypeName: com.azure.core.v2.annotation.ServiceMethod
 
   # Recipe that changes all instances of com.azure.core.annotation.Generated
   # to com.azure.core.v2.annotation.Generated
-  # TODO: Add unit test for this recipe
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: com.azure.core.annotation.Generated
       newFullyQualifiedTypeName: com.azure.core.v2.annotation.Generated
 
   # Recipe that changes all instances of com.azure.core.annotation.Immutable
   # to com.azure.core.v2.annotation.Immutable
-  # TODO: Add unit test for this recipe
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: com.azure.core.annotation.Immutable
       newFullyQualifiedTypeName: com.azure.core.v2.annotation.Immutable
 
   # Recipe that changes all instances of com.azure.core.annotation.ReturnType
   # to com.azure.core.v2.annotation.ReturnType
-  # TODO: Add unit test for this recipe
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: com.azure.core.annotation.ReturnType
       newFullyQualifiedTypeName: com.azure.core.v2.annotation.ReturnType

--- a/rewrite-java-core/src/main/resources/META-INF/rewrite/rewrite.yml
+++ b/rewrite-java-core/src/main/resources/META-INF/rewrite/rewrite.yml
@@ -99,7 +99,7 @@ recipeList:
   # Recipes to migrate implementations of com.azure.core.client.traits.HttpTrait
   # to io.clientcore.core.models.traits.HttpTrait
   # Add http prefix to renamed methods
-  # TODO: Add unit tests for the below recipes
+  # TODO: Filter for implementing classes
   - org.openrewrite.java.ChangeMethodName:
       methodPattern: com.azure.core.client.traits.HttpTrait retryOptions(..)
       newMethodName: httpRetryOptions
@@ -112,6 +112,8 @@ recipeList:
       methodPattern: com.azure.core.client.traits.HttpTrait addPolicy(..)
       newMethodName: addHttpPipelinePolicy
       matchOverrides: true
+  # TODO: Delete method clientOptions
+  # TODO: Add method httpRedirectOptions and HttpRedirectOptions variable
       # End HttpTrait recipes
   # Recipe to change com.azure.core.credential package name to io.clientcore.core.credential
   - org.openrewrite.java.ChangePackage:

--- a/rewrite-java-core/src/test/java/HttpTraitTest.java
+++ b/rewrite-java-core/src/test/java/HttpTraitTest.java
@@ -9,8 +9,7 @@ import static org.openrewrite.java.Assertions.java;
 /**
  * HttpTraitTest tests interface migration from com.azure.core.client.traits.HttpTrait
  * to io.clientcore.core.models.traits.HttpTrait.
- * Tests:
- * Simple method renaming with declarative recipe.
+ * Tests simple method renaming with declarative recipe.
  * CURRENTLY UNFINISHED. All tests for HttpTrait migration will be added here.
  * @author Annabelle Mittendorf Smith
  */
@@ -22,7 +21,6 @@ public class HttpTraitTest implements RewriteTest {
      */
     @Override
     public void defaults(RecipeSpec spec) {
-        // Declarative recipes defined in rewrite.yml
         spec.recipes(new ChangeMethodName("com.azure.core.client.traits.HttpTrait retryOptions(..)",
                 "httpRetryOptions",
                 true, false),
@@ -36,95 +34,10 @@ public class HttpTraitTest implements RewriteTest {
     }
 
     /**
-     * Basic implementation of starting interface com.azure.core.client.traits.HttpTrait
-     */
-    @Language("java") String blankBefore = "import com.azure.core.client.traits.HttpTrait;\n" +
-            "import com.azure.core.http.HttpClient;\n" +
-            "import com.azure.core.http.HttpPipeline;\n" +
-            "import com.azure.core.http.policy.HttpLogOptions;\n" +
-            "import com.azure.core.http.policy.HttpPipelinePolicy;\n" +
-            "import com.azure.core.http.policy.RetryOptions;\n" +
-            "import com.azure.core.util.ClientOptions;\n" +
-            "\n" +
-            "public class BlankHttpTrait implements HttpTrait<BlankHttpTrait> {\n" +
-            "    @Override\n" +
-            "    public BlankHttpTrait httpClient(HttpClient httpClient) {\n" +
-            "        return null;\n" +
-            "    }\n" +
-            "\n" +
-            "    @Override\n" +
-            "    public BlankHttpTrait pipeline(HttpPipeline pipeline) {\n" +
-            "        return null;\n" +
-            "    }\n" +
-            "\n" +
-            "    @Override\n" +
-            "    public BlankHttpTrait addPolicy(HttpPipelinePolicy pipelinePolicy) {\n" +
-            "        return null;\n" +
-            "    }\n" +
-            "\n" +
-            "    @Override\n" +
-            "    public BlankHttpTrait retryOptions(RetryOptions retryOptions) {\n" +
-            "        return null;\n" +
-            "    }\n" +
-            "\n" +
-            "    @Override\n" +
-            "    public BlankHttpTrait httpLogOptions(HttpLogOptions logOptions) {\n" +
-            "        return null;\n" +
-            "    }\n" +
-            "\n" +
-            "    @Override\n" +
-            "    public BlankHttpTrait clientOptions(ClientOptions clientOptions) {\n" +
-            "        return null;\n" +
-            "    }\n" +
-            "}";
-
-    /**
-     * Basic implementation of target interface io.clientcore.core.models.traits.HttpTrait
-     */
-    @Language("java") String blankAfter = "import io.clientcore.core.http.client.HttpClient;\n" +
-            "import io.clientcore.core.http.models.HttpLogOptions;\n" +
-            "import io.clientcore.core.http.models.HttpRedirectOptions;\n" +
-            "import io.clientcore.core.http.models.HttpRetryOptions;\n" +
-            "import io.clientcore.core.http.pipeline.HttpPipeline;\n" +
-            "import io.clientcore.core.http.pipeline.HttpPipelinePolicy;\n" +
-            "import io.clientcore.core.models.traits.HttpTrait;\n" +
-            "\n" +
-            "public class BlankHttpTrait implements HttpTrait<BlankHttpTrait> {\n" +
-            "    @Override\n" +
-            "    public BlankHttpTrait httpClient(HttpClient client) {\n" +
-            "        return null;\n" +
-            "    }\n" +
-            "\n" +
-            "    @Override\n" +
-            "    public BlankHttpTrait httpPipeline(HttpPipeline pipeline) {\n" +
-            "        return null;\n" +
-            "    }\n" +
-            "\n" +
-            "    @Override\n" +
-            "    public BlankHttpTrait addHttpPipelinePolicy(HttpPipelinePolicy pipelinePolicy) {\n" +
-            "        return null;\n" +
-            "    }\n" +
-            "\n" +
-            "    @Override\n" +
-            "    public BlankHttpTrait httpRetryOptions(HttpRetryOptions retryOptions) {\n" +
-            "        return null;\n" +
-            "    }\n" +
-            "\n" +
-            "    @Override\n" +
-            "    public BlankHttpTrait httpLogOptions(HttpLogOptions logOptions) {\n" +
-            "        return null;\n" +
-            "    }\n" +
-            "\n" +
-            "    @Override\n" +
-            "    public BlankHttpTrait httpRedirectOptions(HttpRedirectOptions redirectOptions) {\n" +
-            "        return null;\n" +
-            "    }\n" +
-            "}";
-    /**
      * Test that non-interface methods with the same name are not altered.
      */
     @Test
-    void doesNotChangeNonInheritedMethods() {
+    void testDoesNotChangeNonInheritedMethods() {
         @Language("java")String noChange = "public class TestClass {\n" +
                 "    public void retryOptions() {\n" +
                 "    }\n" +
@@ -144,6 +57,46 @@ public class HttpTraitTest implements RewriteTest {
      */
     @Test
     void declarativeRenameMethodsSuccessful() {
+        @Language("java") String before = "import com.azure.core.client.traits.HttpTrait;\n" +
+                "import com.azure.core.http.HttpClient;\n" +
+                "import com.azure.core.http.HttpPipeline;\n" +
+                "import com.azure.core.http.policy.HttpLogOptions;\n" +
+                "import com.azure.core.http.policy.HttpPipelinePolicy;\n" +
+                "import com.azure.core.http.policy.RetryOptions;\n" +
+                "import com.azure.core.util.ClientOptions;\n" +
+                "\n" +
+                "public class BlankHttpTrait implements HttpTrait<BlankHttpTrait> {\n" +
+                "    @Override\n" +
+                "    public BlankHttpTrait httpClient(HttpClient httpClient) {\n" +
+                "        return null;\n" +
+                "    }\n" +
+                "\n" +
+                "    @Override\n" +
+                "    public BlankHttpTrait pipeline(HttpPipeline pipeline) {\n" +
+                "        return null;\n" +
+                "    }\n" +
+                "\n" +
+                "    @Override\n" +
+                "    public BlankHttpTrait addPolicy(HttpPipelinePolicy pipelinePolicy) {\n" +
+                "        return null;\n" +
+                "    }\n" +
+                "\n" +
+                "    @Override\n" +
+                "    public BlankHttpTrait retryOptions(RetryOptions retryOptions) {\n" +
+                "        return null;\n" +
+                "    }\n" +
+                "\n" +
+                "    @Override\n" +
+                "    public BlankHttpTrait httpLogOptions(HttpLogOptions logOptions) {\n" +
+                "        return null;\n" +
+                "    }\n" +
+                "\n" +
+                "    @Override\n" +
+                "    public BlankHttpTrait clientOptions(ClientOptions clientOptions) {\n" +
+                "        return null;\n" +
+                "    }\n" +
+                "}";
+
         @Language("java") String after = "import com.azure.core.client.traits.HttpTrait;\n" +
                 "import com.azure.core.http.HttpClient;\n" +
                 "import com.azure.core.http.HttpPipeline;\n" +
@@ -185,7 +138,7 @@ public class HttpTraitTest implements RewriteTest {
                 "}";
 
         rewriteRun(
-                java(blankBefore,after)
+                java(before,after)
         );
     }
 

--- a/rewrite-java-core/src/test/java/HttpTraitTest.java
+++ b/rewrite-java-core/src/test/java/HttpTraitTest.java
@@ -1,0 +1,192 @@
+import org.intellij.lang.annotations.Language;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.ChangeMethodName;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+/**
+ * HttpTraitTest tests interface migration from com.azure.core.client.traits.HttpTrait
+ * to io.clientcore.core.models.traits.HttpTrait.
+ * Tests:
+ * Simple method renaming with declarative recipe.
+ * CURRENTLY UNFINISHED. All tests for HttpTrait migration will be added here.
+ * @author Annabelle Mittendorf Smith
+ */
+
+public class HttpTraitTest implements RewriteTest {
+    /**
+     * This method defines recipes used for testing.
+     * @param spec stores settings for testing environment.
+     */
+    @Override
+    public void defaults(RecipeSpec spec) {
+        // Declarative recipes defined in rewrite.yml
+        spec.recipes(new ChangeMethodName("com.azure.core.client.traits.HttpTrait retryOptions(..)",
+                "httpRetryOptions",
+                true, false),
+                new ChangeMethodName("com.azure.core.client.traits.HttpTrait pipeline(..)",
+                        "httpPipeline",
+                        true, false),
+                new ChangeMethodName("com.azure.core.client.traits.HttpTrait addPolicy(..)",
+                        "addHttpPipelinePolicy",
+                        true, false));
+
+    }
+
+    /**
+     * Basic implementation of starting interface com.azure.core.client.traits.HttpTrait
+     */
+    @Language("java") String blankBefore = "import com.azure.core.client.traits.HttpTrait;\n" +
+            "import com.azure.core.http.HttpClient;\n" +
+            "import com.azure.core.http.HttpPipeline;\n" +
+            "import com.azure.core.http.policy.HttpLogOptions;\n" +
+            "import com.azure.core.http.policy.HttpPipelinePolicy;\n" +
+            "import com.azure.core.http.policy.RetryOptions;\n" +
+            "import com.azure.core.util.ClientOptions;\n" +
+            "\n" +
+            "public class BlankHttpTrait implements HttpTrait<BlankHttpTrait> {\n" +
+            "    @Override\n" +
+            "    public BlankHttpTrait httpClient(HttpClient httpClient) {\n" +
+            "        return null;\n" +
+            "    }\n" +
+            "\n" +
+            "    @Override\n" +
+            "    public BlankHttpTrait pipeline(HttpPipeline pipeline) {\n" +
+            "        return null;\n" +
+            "    }\n" +
+            "\n" +
+            "    @Override\n" +
+            "    public BlankHttpTrait addPolicy(HttpPipelinePolicy pipelinePolicy) {\n" +
+            "        return null;\n" +
+            "    }\n" +
+            "\n" +
+            "    @Override\n" +
+            "    public BlankHttpTrait retryOptions(RetryOptions retryOptions) {\n" +
+            "        return null;\n" +
+            "    }\n" +
+            "\n" +
+            "    @Override\n" +
+            "    public BlankHttpTrait httpLogOptions(HttpLogOptions logOptions) {\n" +
+            "        return null;\n" +
+            "    }\n" +
+            "\n" +
+            "    @Override\n" +
+            "    public BlankHttpTrait clientOptions(ClientOptions clientOptions) {\n" +
+            "        return null;\n" +
+            "    }\n" +
+            "}";
+
+    /**
+     * Basic implementation of target interface io.clientcore.core.models.traits.HttpTrait
+     */
+    @Language("java") String blankAfter = "import io.clientcore.core.http.client.HttpClient;\n" +
+            "import io.clientcore.core.http.models.HttpLogOptions;\n" +
+            "import io.clientcore.core.http.models.HttpRedirectOptions;\n" +
+            "import io.clientcore.core.http.models.HttpRetryOptions;\n" +
+            "import io.clientcore.core.http.pipeline.HttpPipeline;\n" +
+            "import io.clientcore.core.http.pipeline.HttpPipelinePolicy;\n" +
+            "import io.clientcore.core.models.traits.HttpTrait;\n" +
+            "\n" +
+            "public class BlankHttpTrait implements HttpTrait<BlankHttpTrait> {\n" +
+            "    @Override\n" +
+            "    public BlankHttpTrait httpClient(HttpClient client) {\n" +
+            "        return null;\n" +
+            "    }\n" +
+            "\n" +
+            "    @Override\n" +
+            "    public BlankHttpTrait httpPipeline(HttpPipeline pipeline) {\n" +
+            "        return null;\n" +
+            "    }\n" +
+            "\n" +
+            "    @Override\n" +
+            "    public BlankHttpTrait addHttpPipelinePolicy(HttpPipelinePolicy pipelinePolicy) {\n" +
+            "        return null;\n" +
+            "    }\n" +
+            "\n" +
+            "    @Override\n" +
+            "    public BlankHttpTrait httpRetryOptions(HttpRetryOptions retryOptions) {\n" +
+            "        return null;\n" +
+            "    }\n" +
+            "\n" +
+            "    @Override\n" +
+            "    public BlankHttpTrait httpLogOptions(HttpLogOptions logOptions) {\n" +
+            "        return null;\n" +
+            "    }\n" +
+            "\n" +
+            "    @Override\n" +
+            "    public BlankHttpTrait httpRedirectOptions(HttpRedirectOptions redirectOptions) {\n" +
+            "        return null;\n" +
+            "    }\n" +
+            "}";
+    /**
+     * Test that non-interface methods with the same name are not altered.
+     */
+    @Test
+    void doesNotChangeNonInheritedMethods() {
+        @Language("java")String noChange = "public class TestClass {\n" +
+                "    public void retryOptions() {\n" +
+                "    }\n" +
+                "    public void pipeline() {\n" +
+                "    }\n" +
+                "    public void addPolicy() {\n" +
+                "    }\n" +
+                "}\n";
+        rewriteRun(java(noChange));
+    }
+
+    /**
+     * Test simple declarative rename of:
+     * retryOptions() to httpRetryOptions()
+     * pipeline() to httpPipeline()
+     * addPolicy() to addHttpPipelinePolicy
+     */
+    @Test
+    void declarativeRenameMethodsSuccessful() {
+        @Language("java") String after = "import com.azure.core.client.traits.HttpTrait;\n" +
+                "import com.azure.core.http.HttpClient;\n" +
+                "import com.azure.core.http.HttpPipeline;\n" +
+                "import com.azure.core.http.policy.HttpLogOptions;\n" +
+                "import com.azure.core.http.policy.HttpPipelinePolicy;\n" +
+                "import com.azure.core.http.policy.RetryOptions;\n" +
+                "import com.azure.core.util.ClientOptions;\n" +
+                "\n" +
+                "public class BlankHttpTrait implements HttpTrait<BlankHttpTrait> {\n" +
+                "    @Override\n" +
+                "    public BlankHttpTrait httpClient(HttpClient httpClient) {\n" +
+                "        return null;\n" +
+                "    }\n" +
+                "\n" +
+                "    @Override\n" +
+                "    public BlankHttpTrait httpPipeline(HttpPipeline pipeline) {\n" +
+                "        return null;\n" +
+                "    }\n" +
+                "\n" +
+                "    @Override\n" +
+                "    public BlankHttpTrait addHttpPipelinePolicy(HttpPipelinePolicy pipelinePolicy) {\n" +
+                "        return null;\n" +
+                "    }\n" +
+                "\n" +
+                "    @Override\n" +
+                "    public BlankHttpTrait httpRetryOptions(RetryOptions retryOptions) {\n" +
+                "        return null;\n" +
+                "    }\n" +
+                "\n" +
+                "    @Override\n" +
+                "    public BlankHttpTrait httpLogOptions(HttpLogOptions logOptions) {\n" +
+                "        return null;\n" +
+                "    }\n" +
+                "\n" +
+                "    @Override\n" +
+                "    public BlankHttpTrait clientOptions(ClientOptions clientOptions) {\n" +
+                "        return null;\n" +
+                "    }\n" +
+                "}";
+
+        rewriteRun(
+                java(blankBefore,after)
+        );
+    }
+
+}

--- a/rewrite-java-core/src/test/java/ServiceAnnotationsTest.java
+++ b/rewrite-java-core/src/test/java/ServiceAnnotationsTest.java
@@ -1,0 +1,191 @@
+import org.intellij.lang.annotations.Language;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.ChangeType;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+/**
+ * ServiceAnnotationTest tests declarative ChangeType recipe on ServiceClient
+ * related annotations from com.azure.core.annotations to
+ * com.azure.core.v2.annotations
+ * NOTE
+ * Double up in both packages of ReturnType, ServiceClient, ServiceClientBuilder,
+ * ServiceInterface and ServiceMethod.
+ * Also tests non-ServiceClient annotation Immutable
+ * @author Annabelle Mittendorf Smith
+ */
+public class ServiceAnnotationsTest implements RewriteTest {
+
+    /**
+     * This method sets which recipe should be used for testing
+     * @param spec stores settings for testing environment; e.g. which recipes to use for testing
+     */
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipes(
+                new ChangeType("com.azure.core.annotation.ServiceClient",
+                        "com.azure.core.v2.annotation.ServiceClient", null),
+
+                new ChangeType("com.azure.core.annotation.ServiceClientBuilder",
+                        "com.azure.core.v2.annotation.ServiceClientBuilder", null),
+
+                new ChangeType("com.azure.core.annotation.ServiceInterface",
+                        "io.clientcore.core.annotation.ServiceInterface", null),
+
+                new ChangeType("com.azure.core.annotation.ServiceMethod",
+                        "com.azure.core.v2.annotation.ServiceMethod", null),
+
+                new ChangeType("com.azure.core.annotation.Generated",
+                        "com.azure.core.v2.annotation.Generated", null),
+
+                new ChangeType("com.azure.core.annotation.Immutable",
+                        "com.azure.core.v2.annotation.Immutable", null),
+
+                new ChangeType("com.azure.core.annotation.ReturnType",
+                        "com.azure.core.v2.annotation.ReturnType",null)
+        );
+    }
+
+    /**
+     * Global Java language strings to help testing.
+     */
+    @Language("java") String before, after;
+
+    @BeforeEach
+    public void setup() {
+        before = ""; after = "";
+    }
+
+    @Test
+    public void testServiceClientAndBuilder() {
+        before = "import com.azure.core.annotation.ServiceClient;\n" +
+                "import com.azure.core.annotation.ServiceClientBuilder;\n" +
+                "\n" +
+                "@ServiceClient(builder = ServiceClientBuilder.class)\n" +
+                "@ServiceClientBuilder(serviceClients = {TestServiceClient.class})\n" +
+                "public class TestServiceClient {\n" +
+                "}\n";
+
+        after = "import com.azure.core.v2.annotation.ServiceClient;\n" +
+                "import com.azure.core.v2.annotation.ServiceClientBuilder;\n" +
+                "\n" +
+                "@ServiceClient(builder = ServiceClientBuilder.class)\n" +
+                "@ServiceClientBuilder(serviceClients = {TestServiceClient.class})\n" +
+                "public class TestServiceClient {\n" +
+                "}\n";
+
+        rewriteRun(java(before,after));
+    }
+
+    /**
+     * ServiceInterface changes to io.clientcore.core.annotations
+     */
+    @Test
+    public void testServiceInterface() {
+        before = "import com.azure.core.annotation.ServiceInterface;\n" +
+                "\n" +
+                "@ServiceInterface(name = \"ServiceInterface\")\n" +
+                "public interface ServiceInterface {\n" +
+                "}";
+
+        after = "import io.clientcore.core.annotation.ServiceInterface;\n" +
+                "\n" +
+                "@ServiceInterface(name = \"ServiceInterface\")\n" +
+                "public interface ServiceInterface {\n" +
+                "}";
+
+        rewriteRun(java(before,after));
+    }
+
+    @Test
+    public void testServiceMethod() {
+        before = "import com.azure.core.annotation.ServiceInterface;\n" +
+                "import com.azure.core.annotation.ServiceMethod;\n" +
+                "\n" +
+                "@ServiceInterface(name = \"ServiceInterface\")\n" +
+                "public interface ServiceInterface {\n" +
+                "   @ServiceMethod()\n" +
+                "   void serviceMethod();\n" +
+                "}";
+
+        after = "import com.azure.core.v2.annotation.ServiceMethod;\n" +
+                "import io.clientcore.core.annotation.ServiceInterface;\n" +
+                "\n" +
+                "@ServiceInterface(name = \"ServiceInterface\")\n" +
+                "public interface ServiceInterface {\n" +
+                "   @ServiceMethod()\n" +
+                "   void serviceMethod();\n" +
+                "}";
+
+        rewriteRun(java(before,after));
+    }
+
+    @Test
+    public void testGenerated() {
+        before = "import com.azure.core.annotation.ServiceInterface;\n" +
+                "import com.azure.core.annotation.Generated;\n" +
+                "\n" +
+                "@ServiceInterface(name = \"ServiceInterface\")\n" +
+                "public interface ServiceInterface {\n" +
+                "   @Generated\n" +
+                "   String Name;\n" +
+                "}";
+
+        after = "import com.azure.core.v2.annotation.Generated;\n" +
+                "import io.clientcore.core.annotation.ServiceInterface;\n" +
+                "\n" +
+                "@ServiceInterface(name = \"ServiceInterface\")\n" +
+                "public interface ServiceInterface {\n" +
+                "   @Generated\n" +
+                "   String Name;\n" +
+                "}";
+
+        rewriteRun(java(before,after));
+    }
+
+    @Test
+    public void testReturnType() {
+        before = "import com.azure.core.annotation.ServiceInterface;\n" +
+                "import com.azure.core.annotation.ReturnType;\n" +
+                "\n" +
+                "@ServiceInterface(name = \"ServiceInterface\")\n" +
+                "public interface ServiceInterface {\n" +
+                "   ReturnType returnType;\n" +
+                "}";
+
+        after = "import com.azure.core.v2.annotation.ReturnType;\n" +
+                "import io.clientcore.core.annotation.ServiceInterface;\n" +
+                "\n" +
+                "@ServiceInterface(name = \"ServiceInterface\")\n" +
+                "public interface ServiceInterface {\n" +
+                "   ReturnType returnType;\n" +
+                "}";
+
+        rewriteRun(java(before,after));
+    }
+
+    /**
+     * Immutable is not a ServiceClient annotation.
+     */
+    @Test
+    public void testImmutable() {
+        before = "import com.azure.core.annotation.Immutable;\n" +
+                "\n" +
+                "@Immutable\n" +
+                "public final class TestImmutable {\n" +
+                "   private final String val;\n" +
+                "}";
+
+        after = "import com.azure.core.v2.annotation.Immutable;\n" +
+                "\n" +
+                "@Immutable\n" +
+                "public final class TestImmutable {\n" +
+                "   private final String val;\n" +
+                "}";
+
+        rewriteRun(java(before,after));
+    }
+}


### PR DESCRIPTION
Unit tests added for the following ChangeType recipes:
from com-azure-core-annotation to com-azure-core-v2-annotation:
- ServiceClient
- ServiceClientBuilder
- ServiceMethod
- Generated
- ReturnType
- Immutable

from com-azure-core-annotation to io-clientcore-core-annotation:
- ServiceInterface