### PR TITLE
Refactored unit tests

### DIFF
--- a/rewrite-java-core/src/test/java/CredentialTest.java
+++ b/rewrite-java-core/src/test/java/CredentialTest.java
@@ -11,7 +11,7 @@ import static org.openrewrite.java.Assertions.java;
  * to io.clientcore.core.credential.
  * @author Ali Soltanian Fard Jahromi
  */
-class CredentialTest implements RewriteTest {
+public class CredentialTest implements RewriteTest {
 
     /**
      * This method sets which recipe should be used for testing
@@ -19,15 +19,15 @@ class CredentialTest implements RewriteTest {
      */
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.recipe(new ChangePackage("com.azure.core.credential",
-                "io.clientcore.core.credential", null));
+        spec.recipeFromResource("/META-INF/rewrite/rewrite.yml",
+                "com.azure.rewrite.java.core.MigrateAzureCoreSamplesToAzureCoreV2");
     }
 
     /**
      * This test method is used to make sure that the package com.azure.core.credential is changed
      */
     @Test
-    void testPackageNameChange() {
+    void testCredentialPackageNameChange() {
         @Language("java") String before = "import com.azure.core.credential.KeyCredential;";
         before += "\npublic class Testing {";
         before += "\n  public Testing(){";

--- a/rewrite-java-core/src/test/java/HttpTraitTest.java
+++ b/rewrite-java-core/src/test/java/HttpTraitTest.java
@@ -21,15 +21,8 @@ public class HttpTraitTest implements RewriteTest {
      */
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.recipes(new ChangeMethodName("com.azure.core.client.traits.HttpTrait retryOptions(..)",
-                "httpRetryOptions",
-                true, false),
-                new ChangeMethodName("com.azure.core.client.traits.HttpTrait pipeline(..)",
-                        "httpPipeline",
-                        true, false),
-                new ChangeMethodName("com.azure.core.client.traits.HttpTrait addPolicy(..)",
-                        "addHttpPipelinePolicy",
-                        true, false));
+        spec.recipeFromResource("/META-INF/rewrite/rewrite.yml",
+                "com.azure.rewrite.java.core.MigrateAzureCoreSamplesToAzureCoreV2");
 
     }
 

--- a/rewrite-java-core/src/test/java/ParamAnnotationTest.java
+++ b/rewrite-java-core/src/test/java/ParamAnnotationTest.java
@@ -11,56 +11,87 @@ import static org.openrewrite.java.Assertions.java;
  * , @BodyParam and @QueryParam annotations.
  * @author Ali Soltanian Fard Jahromi
  */
-class ParamAnnotationTest implements RewriteTest {
+public class ParamAnnotationTest implements RewriteTest {
     /**
      * This method sets which recipe should be used for testing
      * @param spec stores settings for testing environment; e.g. which recipes to use for testing
      */
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.recipes(new ChangeType("com.azure.core.annotation.HostParam",
-                "io.clientcore.core.http.annotation.HostParam", null),
-
-                new ChangeType("com.azure.core.annotation.HeaderParam",
-                        "io.clientcore.core.http.annotation.HeaderParam", null),
-
-                new ChangeType("com.azure.core.annotation.QueryParam",
-                        "io.clientcore.core.http.annotation.QueryParam", null),
-
-                new ChangeType("com.azure.core.annotation.BodyParam",
-                        "io.clientcore.core.http.annotation.BodyParam", null));
+        spec.recipeFromResource("/META-INF/rewrite/rewrite.yml",
+                "com.azure.rewrite.java.core.MigrateAzureCoreSamplesToAzureCoreV2");
     }
 
     /**
-     * This test method is used to make sure that the annotation types are changed correctly
-     */
+     * This method tests to make sure the @HostParam annotation type is changed
+     * */
     @Test
-    void testParam() {
-        @Language("java") String before = "import com.azure.core.annotation.HostParam;" +
-                "\nimport com.azure.core.annotation.BodyParam;" +
-                "\nimport com.azure.core.util.Context;" +
-                "\nimport com.azure.core.util.BinaryData;" +
-                "\nimport com.azure.core.annotation.QueryParam;" +
-                "\nimport com.azure.core.annotation.HeaderParam;" +
-                "\nimport com.azure.core.http.rest.RequestOptions;";
+    void testHostParam() {
+        @Language("java") String before = "import com.azure.core.annotation.HostParam;\n" +
+                "@HostParam(host = HostParam.class)\n";
         before += "\npublic class Testing {";
-        before += "\n  ";
-        before += "\n    Response<BinaryData> getSupportedLanguagesSync(@BodyParam(\"application/json\") BinaryData body, @HostParam(\"Endpoint\") String endpoint, @QueryParam(\"api-version\") String apiVersion, @HeaderParam(\"accept\") String accept, RequestOptions requestOptions, Context context);";
-        before += "\n  ";
         before += "\n}";
 
-        @Language("java") String after =
-                "\nimport com.azure.core.util.Context;" +
-                "\nimport io.clientcore.core.http.annotation.BodyParam;" +
-                "\nimport io.clientcore.core.http.annotation.HeaderParam;" +
-                "\nimport io.clientcore.core.http.annotation.HostParam;" +
-                "\nimport io.clientcore.core.http.annotation.QueryParam;" +
-                "\nimport com.azure.core.util.BinaryData;" +
-                "\nimport com.azure.core.http.rest.RequestOptions;";
-        after += "\n\npublic class Testing {";
-        after += "\n  ";
-        after += "\n    Response<BinaryData> getSupportedLanguagesSync(@BodyParam(\"application/json\") BinaryData body, @HostParam(\"Endpoint\") String endpoint, @QueryParam(\"api-version\") String apiVersion, @HeaderParam(\"accept\") String accept, RequestOptions requestOptions, Context context);";
-        after += "\n  ";
+        @Language("java") String after = "import io.clientcore.core.http.annotation.HostParam;\n\n" +
+                "@HostParam(host = HostParam.class)\n";
+        after += "\npublic class Testing {";
+        after += "\n}";
+        rewriteRun(
+                java(before,after)
+        );
+    }
+
+    /**
+     * This method tests to make sure the @HeaderParam annotation type is changed
+     * */
+    @Test
+    void testHeaderParam() {
+        @Language("java") String before = "import com.azure.core.annotation.HeaderParam;\n" +
+                "@HeaderParam(header = HeaderParam.class)\n";
+        before += "\npublic class Testing {";
+        before += "\n}";
+
+        @Language("java") String after = "import io.clientcore.core.http.annotation.HeaderParam;\n\n" +
+                "@HeaderParam(header = HeaderParam.class)\n";
+        after += "\npublic class Testing {";
+        after += "\n}";
+        rewriteRun(
+                java(before,after)
+        );
+    }
+
+    /**
+     * This method tests to make sure the @BodyParam annotation type is changed
+     * */
+    @Test
+    void testBodyParam() {
+        @Language("java") String before = "import com.azure.core.annotation.BodyParam;\n" +
+                "@BodyParam(body = BodyParam.class)\n";
+        before += "\npublic class Testing {";
+        before += "\n}";
+
+        @Language("java") String after = "import io.clientcore.core.http.annotation.BodyParam;\n\n" +
+                        "@BodyParam(body = BodyParam.class)\n";
+        after += "\npublic class Testing {";
+        after += "\n}";
+        rewriteRun(
+                java(before,after)
+        );
+    }
+
+    /**
+     * This method tests to make sure the @QueryParam annotation type is changed
+     * */
+    @Test
+    void testQueryParam() {
+        @Language("java") String before = "import com.azure.core.annotation.QueryParam;\n" +
+                "@QueryParam(query = QueryParam.class)\n";
+        before += "\npublic class Testing {";
+        before += "\n}";
+
+        @Language("java") String after = "import io.clientcore.core.http.annotation.QueryParam;\n\n" +
+                "@QueryParam(query = QueryParam.class)\n";
+        after += "\npublic class Testing {";
         after += "\n}";
         rewriteRun(
                 java(before,after)

--- a/rewrite-java-core/src/test/java/ServiceAnnotationsTest.java
+++ b/rewrite-java-core/src/test/java/ServiceAnnotationsTest.java
@@ -25,28 +25,8 @@ public class ServiceAnnotationsTest implements RewriteTest {
      */
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.recipes(
-                new ChangeType("com.azure.core.annotation.ServiceClient",
-                        "com.azure.core.v2.annotation.ServiceClient", null),
-
-                new ChangeType("com.azure.core.annotation.ServiceClientBuilder",
-                        "com.azure.core.v2.annotation.ServiceClientBuilder", null),
-
-                new ChangeType("com.azure.core.annotation.ServiceInterface",
-                        "io.clientcore.core.annotation.ServiceInterface", null),
-
-                new ChangeType("com.azure.core.annotation.ServiceMethod",
-                        "com.azure.core.v2.annotation.ServiceMethod", null),
-
-                new ChangeType("com.azure.core.annotation.Generated",
-                        "com.azure.core.v2.annotation.Generated", null),
-
-                new ChangeType("com.azure.core.annotation.Immutable",
-                        "com.azure.core.v2.annotation.Immutable", null),
-
-                new ChangeType("com.azure.core.annotation.ReturnType",
-                        "com.azure.core.v2.annotation.ReturnType",null)
-        );
+        spec.recipeFromResource("/META-INF/rewrite/rewrite.yml",
+                "com.azure.rewrite.java.core.MigrateAzureCoreSamplesToAzureCoreV2");
     }
 
     /**


### PR DESCRIPTION
This PR will make some minor adjustments to the unit tests according to the feedback received from Microsoft for previous PR.

### Changes in this PR:
- Ensured all unit test classes are `public`
- Loaded entire `rewrite.yaml` recipe rather than manually loading OpenRewrite recipes (like `ChangeType` or `ChangeMethodName`) directly from their library
- Cleaned up and added some more unit tests in `ParamAnnotationTest.java`

resolves #44 