### PR TITLE
Fixed bug that crashed the RetryOptionsConstructorRecipe

### DIFF
--- a/rewrite-java-core/src/main/java/com/azure/recipes/v2recipes/RetryOptionsConstructorRecipe.java
+++ b/rewrite-java-core/src/main/java/com/azure/recipes/v2recipes/RetryOptionsConstructorRecipe.java
@@ -60,7 +60,12 @@ public class RetryOptionsConstructorRecipe extends Recipe {
         public J.VariableDeclarations visitVariableDeclarations(J.VariableDeclarations variableDeclarations, ExecutionContext executionContext) {
             J.VariableDeclarations vd = super.visitVariableDeclarations(variableDeclarations, executionContext);
             for (J.VariableDeclarations.NamedVariable variable : vd.getVariables()) {
-                J.NewClass newClass = (J.NewClass) variable.getInitializer();
+                J.NewClass newClass = null;
+                try {
+                    newClass = (J.NewClass) variable.getInitializer();
+                } catch (Exception e) {
+                    return vd;
+                }
                 if (newClass != null) {
                     String className = newClass.getType().toString();
                     if (className.contains("FixedDelayOptions") || className.contains("ExponentialDelayOptions")) {

--- a/rewrite-java-core/src/test/java/RetryOptionsConstructorTest.java
+++ b/rewrite-java-core/src/test/java/RetryOptionsConstructorTest.java
@@ -56,16 +56,20 @@ public class RetryOptionsConstructorTest implements RewriteTest {
         @Language("java") String before = "import com.azure.core.http.policy.RetryOptions;import java.time.Duration;import com.azure.core.http.policy.FixedDelayOptions;";
         before += "\npublic class Testing {";
         before += "\n  FixedDelayOptions f = new FixedDelayOptions(3, Duration.ofMillis(50));";
+        before += "\n  String test = \"testing\";";
         before += "\n  public Testing(){";
         before += "\n    com.azure.core.http.policy.RetryOptions r = new RetryOptions(f);";
+        before += "\n     test = \"test\";";
         before += "\n  }";
         before += "\n}";
 
         @Language("java") String after = "import io.clientcore.core.http.models.HttpRetryOptions;import java.time.Duration;import com.azure.core.http.policy.FixedDelayOptions;";
         after += "\npublic class Testing {";
         after += "\n  FixedDelayOptions f = new FixedDelayOptions(3, Duration.ofMillis(50));";
+        after += "\n  String test = \"testing\";";
         after += "\n  public Testing(){";
         after += "\n     io.clientcore.core.http.models.HttpRetryOptions r = new HttpRetryOptions(3, Duration.ofMillis(50));";
+        after += "\n     test = \"test\";";
         after += "\n  }";
         after += "\n}";
         rewriteRun(


### PR DESCRIPTION
Fixed a bug where the RetryOptionsConstructorRecipe would crash when being applied to files that contain multiple variable instantiations.