### PR TITLE
Added recipes to convert UnexpectedResponseExceptionType and fixed a bug

### DIFF
--- a/rewrite-java-core/src/main/resources/META-INF/rewrite/rewrite.yml
+++ b/rewrite-java-core/src/main/resources/META-INF/rewrite/rewrite.yml
@@ -11,23 +11,28 @@ recipeList:
   #    replace: 'requires $1com.azure.core.v2'
   #    filePattern: '**/module-info.java'
 
-  # Recipes that convert usages of TypeReference to ParameterizedType in toObject() method
-  # - Recipe 1: Changes TypeReference to ParameterizedType for variable declarations
-  # - Recipe 2: Changes TypeReference to ParameterizedType for direct instantiations with 'new' keyword
-  # - Recipe 3: Removes import for com.azure.core.util.serializer.TypeReference
-  - org.openrewrite.text.FindAndReplace: # Recipe 1
-      regex: true
-      find: 'TypeReference<\s*List<(\w+)>\s*>\s+(\w+)\s*=\s*new\s+TypeReference<\s*List<(\w+)>\s*>\(\)\s*\{'
-      replace: 'Type $2 = new ParameterizedType() { @Override public Type getRawType() { return List.class; } @Override public Type[] getActualTypeArguments() { return new Type[] { $1.class }; } @Override public Type getOwnerType() { return null; }'
-  - org.openrewrite.text.FindAndReplace: # Recipe 2
-      regex: true
-      find: 'new\s+TypeReference<\s*List<(\w+)>\s*>\(\)\s*\{'
-      replace: 'new ParameterizedType() { @Override public Type getRawType() { return List.class; } @Override public Type[] getActualTypeArguments() { return new Type[] { $1.class }; } @Override public Type getOwnerType() { return null; }'
-  - org.openrewrite.text.FindAndReplace: # Recipe 3
-      regex: true
-      find: 'import\s+com.azure.core.util.serializer.TypeReference\s*;'
-      replace: ''
-  # End TypeReference -> ParameterizedType recipes
+  # ----------------------------------
+  #
+  # Java-Based LST Replacement Recipes
+  #
+  # ----------------------------------
+
+  # Recipes that converts the parameters and type of the @UnexpectedResponseExceptionType annotation
+  # to @UnexpectedResponseExceptionDetail.
+  # - Recipes 1-2: Change the attribute names
+  # - Recipe 3: Changes the type
+  - org.openrewrite.java.ChangeAnnotationAttributeName:
+      annotationType: com.azure.core.annotation.UnexpectedResponseExceptionType
+      oldAttributeName: value
+      newAttributeName: exceptionTypeName
+  - org.openrewrite.java.ChangeAnnotationAttributeName:
+      annotationType: com.azure.core.annotation.UnexpectedResponseExceptionType
+      oldAttributeName: code
+      newAttributeName: statusCode
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: com.azure.core.annotation.UnexpectedResponseExceptionType
+      newFullyQualifiedTypeName: io.clientcore.core.http.annotation.UnexpectedResponseExceptionDetail
+  # End @UnexpectedResponseExceptionDetail recipes
 
   # Recipe that changes all instances of com.azure.core.http.rest.RequestOptions
   # to io.clientcore.core.http.models.RequestOptions
@@ -130,3 +135,52 @@ recipeList:
   - org.openrewrite.java.ChangePackage:
         oldPackageName: com.azure.core.credential
         newPackageName: io.clientcore.core.credential
+
+  # --------------------------------
+  #
+  # Text Based Replacement Recipes
+  #
+  # --------------------------------
+
+  # Recipes that convert exceptionTypeName parameter in @UnexpectedResponseExceptionDetail annotation
+  # from the CamelCase form to UPPER_CASE form.
+  # - Recipe 1: Adds quotation marks around field, so it can be found easily
+  # - Recipe 2: Converts ClientAuthenticationException
+  # - Recipe 3: Converts ResourceNotFoundException
+  # - Recipe 4: Converts ResourceModifiedException
+  # - Recipe 5: Converts HttpResponseException
+  - org.openrewrite.text.FindAndReplace:
+      regex: true
+      find: '@UnexpectedResponseExceptionDetail\s*\(\s*exceptionTypeName\s*=\s*([\w.]+)\s*(?:,\s*statusCode\s*=\s*\{\s*([0-9]+)\s*\}\s*)?\)'
+      replace: '@UnexpectedResponseExceptionDetail(exceptionTypeName = "$1", statusCode = { $2 })'
+  - org.openrewrite.text.FindAndReplace:
+      find: '"ClientAuthenticationException.class"'
+      replace: '"CLIENT_AUTHENTICATION"'
+  - org.openrewrite.text.FindAndReplace:
+      find: '"ResourceNotFoundException.class"'
+      replace: '"RESOURCE_NOT_FOUND"'
+  - org.openrewrite.text.FindAndReplace:
+      find: '"ResourceModifiedException.class"'
+      replace: '"RESOURCE_MODIFIED"'
+  - org.openrewrite.text.FindAndReplace:
+      find: '@UnexpectedResponseExceptionDetail(exceptionTypeName = "HttpResponseException.class", statusCode = {  })'
+      replace: '@UnexpectedResponseExceptionDetail'
+  # End exceptionTypeName parameter recipes
+
+  # Recipes that convert usages of TypeReference to ParameterizedType in toObject() method
+  # - Recipe 1: Changes TypeReference to ParameterizedType for variable declarations
+  # - Recipe 2: Changes TypeReference to ParameterizedType for direct instantiations with 'new' keyword
+  # - Recipe 3: Removes import for com.azure.core.util.serializer.TypeReference
+  - org.openrewrite.text.FindAndReplace: # Recipe 1
+      regex: true
+      find: 'TypeReference<\s*List<(\w+)>\s*>\s+(\w+)\s*=\s*new\s+TypeReference<\s*List<(\w+)>\s*>\(\)\s*\{'
+      replace: 'Type $2 = new ParameterizedType() { @Override public Type getRawType() { return List.class; } @Override public Type[] getActualTypeArguments() { return new Type[] { $1.class }; } @Override public Type getOwnerType() { return null; }'
+  - org.openrewrite.text.FindAndReplace: # Recipe 2
+      regex: true
+      find: 'new\s+TypeReference<\s*List<(\w+)>\s*>\(\)\s*\{'
+      replace: 'new ParameterizedType() { @Override public Type getRawType() { return List.class; } @Override public Type[] getActualTypeArguments() { return new Type[] { $1.class }; } @Override public Type getOwnerType() { return null; }'
+  - org.openrewrite.text.FindAndReplace: # Recipe 3
+      regex: true
+      find: 'import\s+com.azure.core.util.serializer.TypeReference\s*;'
+      replace: ''
+  # End TypeReference -> ParameterizedType recipes

--- a/rewrite-java-core/src/test/java/UnexpectedResponseExceptionTypeTest.java
+++ b/rewrite-java-core/src/test/java/UnexpectedResponseExceptionTypeTest.java
@@ -1,0 +1,60 @@
+import org.intellij.lang.annotations.Language;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+/**
+ * UnexpectedResponseExceptionTypeTest is used to test out the recipe that changes the usage
+ * of UnexpectedResponseExceptionType (azure core v1) to UnexpectedResponseExceptionDetail (azure core v2)
+ * including all of its parameters.
+ * @author Ali Soltanian Fard Jahromi
+ */
+public class UnexpectedResponseExceptionTypeTest implements RewriteTest {
+
+    /**
+     * This method sets which recipe should be used for testing
+     * @param spec stores settings for testing environment; e.g. which recipes to use for testing
+     */
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipeFromResource("/META-INF/rewrite/rewrite.yml",
+                "com.azure.rewrite.java.core.MigrateAzureCoreSamplesToAzureCoreV2");
+    }
+
+    /**
+     * This test method is used to make sure that UnexpectedResponseExceptionType and
+     * its parameters are converted correctly.
+     */
+    @Test
+    void testUnexpectedResponseExceptionAnnotationChange() {
+        @Language("java") String before = "import com.azure.core.annotation.UnexpectedResponseExceptionType;\n" +
+                "import com.azure.core.exception.ClientAuthenticationException;\n" +
+                "import com.azure.core.exception.HttpResponseException;\n" +
+                "import com.azure.core.exception.ResourceModifiedException;\n" +
+                "import com.azure.core.exception.ResourceNotFoundException;\n" +
+                "public class Testing{" +
+                "@UnexpectedResponseExceptionType(value = ClientAuthenticationException.class, code = { 401 })\n" +
+                        "@UnexpectedResponseExceptionType(value = ResourceNotFoundException.class, code = { 404 })\n" +
+                        "@UnexpectedResponseExceptionType(value = ResourceModifiedException.class, code = { 409 })\n" +
+                        "@UnexpectedResponseExceptionType(HttpResponseException.class)\nprivate String v(){}\n}";
+
+        @Language("java") String after =
+                "import com.azure.core.exception.ClientAuthenticationException;\n" +
+                "import com.azure.core.exception.HttpResponseException;\n" +
+                "import com.azure.core.exception.ResourceModifiedException;\n" +
+                "import com.azure.core.exception.ResourceNotFoundException;\n" +
+                "import io.clientcore.core.http.annotation.UnexpectedResponseExceptionDetail;\n\n" +
+                "public class Testing{" +
+                "@UnexpectedResponseExceptionDetail(exceptionTypeName = \"CLIENT_AUTHENTICATION\", statusCode = { 401 })\n" +
+                        "@UnexpectedResponseExceptionDetail(exceptionTypeName = \"RESOURCE_NOT_FOUND\", statusCode = { 404 })\n" +
+                        "@UnexpectedResponseExceptionDetail(exceptionTypeName = \"RESOURCE_MODIFIED\", statusCode = { 409 })\n" +
+                        "@UnexpectedResponseExceptionDetail\nprivate String v(){}\n}";
+
+        rewriteRun(
+                java(before, after)
+        );
+
+    }
+}


### PR DESCRIPTION
Changes in this PR:
- Added recipes to convert `@ UnexpectedResponseExceptionType` annotation and its parameters
- Reordered recipes so that FindAndReplace recipes are executed after Java-LST based recipes, otherwise Java-LST based recipes will not be executed
- Added unit test for recipes to convert `@ UnexpectedResponseExceptionType` annotation and its parameters

resolves #54 