### PR TITLE
Issue 56 exception types

### DIFF
--- a/rewrite-java-core/src/main/resources/META-INF/rewrite/rewrite.yml
+++ b/rewrite-java-core/src/main/resources/META-INF/rewrite/rewrite.yml
@@ -112,6 +112,24 @@ recipeList:
       oldFullyQualifiedTypeName: com.azure.core.annotation.ReturnType
       newFullyQualifiedTypeName: com.azure.core.v2.annotation.ReturnType
 
+  # Recipes that update all instances of azure-core exceptions where
+  # use is equivalent and type/name change is sufficient/safe.
+  # Update to azure-core-v2 version
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: com.azure.core.exception.ClientAuthenticationException
+      newFullyQualifiedTypeName: com.azure.core.v2.exception.ClientAuthenticationException
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: com.azure.core.exception.ResourceModifiedException
+      newFullyQualifiedTypeName: com.azure.core.v2.exception.ResourceModifiedException
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: com.azure.core.exception.ResourceNotFoundException
+      newFullyQualifiedTypeName: com.azure.core.v2.exception.ResourceNotFoundException
+  # Update to clientcore version
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: com.azure.core.exception.HttpResponseException
+      newFullyQualifiedTypeName: io.clientcore.core.http.exception.HttpResponseException
+  # End azure-core-exception change type Recipes
+
   # Recipes to migrate implementations of com.azure.core.client.traits.HttpTrait
   # to io.clientcore.core.models.traits.HttpTrait
   # Add http prefix to renamed methods

--- a/rewrite-java-core/src/main/resources/META-INF/rewrite/rewrite.yml
+++ b/rewrite-java-core/src/main/resources/META-INF/rewrite/rewrite.yml
@@ -112,23 +112,7 @@ recipeList:
       oldFullyQualifiedTypeName: com.azure.core.annotation.ReturnType
       newFullyQualifiedTypeName: com.azure.core.v2.annotation.ReturnType
 
-  # Recipes that update all instances of azure-core exceptions where
-  # use is equivalent and type/name change is sufficient/safe.
-  # Update to azure-core-v2 version
-  - org.openrewrite.java.ChangeType:
-      oldFullyQualifiedTypeName: com.azure.core.exception.ClientAuthenticationException
-      newFullyQualifiedTypeName: com.azure.core.v2.exception.ClientAuthenticationException
-  - org.openrewrite.java.ChangeType:
-      oldFullyQualifiedTypeName: com.azure.core.exception.ResourceModifiedException
-      newFullyQualifiedTypeName: com.azure.core.v2.exception.ResourceModifiedException
-  - org.openrewrite.java.ChangeType:
-      oldFullyQualifiedTypeName: com.azure.core.exception.ResourceNotFoundException
-      newFullyQualifiedTypeName: com.azure.core.v2.exception.ResourceNotFoundException
-  # Update to clientcore version
-  - org.openrewrite.java.ChangeType:
-      oldFullyQualifiedTypeName: com.azure.core.exception.HttpResponseException
-      newFullyQualifiedTypeName: io.clientcore.core.http.exception.HttpResponseException
-  # End azure-core-exception change type Recipes
+
 
   # Recipes to migrate implementations of com.azure.core.client.traits.HttpTrait
   # to io.clientcore.core.models.traits.HttpTrait
@@ -184,6 +168,25 @@ recipeList:
       find: '@UnexpectedResponseExceptionDetail(exceptionTypeName = "HttpResponseException.class", statusCode = {  })'
       replace: '@UnexpectedResponseExceptionDetail'
   # End exceptionTypeName parameter recipes
+
+  # Recipes that update all instances of azure-core exceptions where
+  # use is equivalent and type/name change is sufficient/safe.
+  # Update to azure-core-v2 version
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: com.azure.core.exception.ClientAuthenticationException
+      newFullyQualifiedTypeName: com.azure.core.v2.exception.ClientAuthenticationException
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: com.azure.core.exception.ResourceModifiedException
+      newFullyQualifiedTypeName: com.azure.core.v2.exception.ResourceModifiedException
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: com.azure.core.exception.ResourceNotFoundException
+      newFullyQualifiedTypeName: com.azure.core.v2.exception.ResourceNotFoundException
+  # Update to clientcore version
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: com.azure.core.exception.HttpResponseException
+      newFullyQualifiedTypeName: io.clientcore.core.http.exception.HttpResponseException
+  # End azure-core-exception change type Recipes
+
   # Recipe that changes all instances of com.azure.core.util.Configuration
   # to io.clientcore.core.util.configuration.Configuration
   - org.openrewrite.java.ChangeType:

--- a/rewrite-java-core/src/test/java/ExceptionTypesTest.java
+++ b/rewrite-java-core/src/test/java/ExceptionTypesTest.java
@@ -1,0 +1,143 @@
+import org.intellij.lang.annotations.Language;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+public class ExceptionTypesTest implements RewriteTest {
+    /**
+     * ExceptionTypesTest tests exception migrations from azure-core v1
+     * to azure-core-v2 and client-core.
+     * Recipes used: ChangeType
+     * From:
+     * com.azure.core.exception
+     *      ClientAuthenticationException
+     *      HttpResponseException
+     *      ResourceModifiedException
+     *      ResourceNotFoundException
+     * To:
+     * com.azure.core.v2.exception
+     *      ClientAuthenticationException
+     *      ResourceModifiedException
+     *      ResourceNotFoundException
+     * io.clientcore.core.http.exception
+     *      HttpResponseException
+     *
+     * @author Annabelle Mittendorf Smith
+     */
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipeFromResource("/META-INF/rewrite/rewrite.yml",
+                "com.azure.rewrite.java.core.MigrateAzureCoreSamplesToAzureCoreV2");
+    }
+
+    /* Testing ChangeType recipes */
+    @Test
+    public void testClientAuthenticationExceptionChanged() {
+        @Language("java") String before = "import com.azure.core.exception.ClientAuthenticationException;";
+        before += "\npublic class Testing {";
+        before += "\n  public Testing(){";
+        before += "\n    com.azure.core.exception.ClientAuthenticationException e = new ClientAuthenticationException();";
+        before += "\n  }";
+        before += "\n}";
+
+        @Language("java") String after = "import com.azure.core.v2.exception.ClientAuthenticationException;";
+        after += "\n\npublic class Testing {";
+        after += "\n  public Testing(){";
+        after += "\n    com.azure.core.v2.exception.ClientAuthenticationException e = new ClientAuthenticationException();";
+        after += "\n  }";
+        after += "\n}";
+
+        rewriteRun(
+                java(before,after)
+        );
+    }
+
+    @Test
+    public void testHttpResponseExceptionChanged() {
+        @Language("java") String before = "import com.azure.core.exception.HttpResponseException;";
+        before += "\npublic class Testing {";
+        before += "\n  public Testing(){";
+        before += "\n    com.azure.core.exception.HttpResponseException e = new HttpResponseException();";
+        before += "\n  }";
+        before += "\n}";
+
+        @Language("java") String after = "import io.clientcore.core.http.exception.HttpResponseException;";
+        after += "\n\npublic class Testing {";
+        after += "\n  public Testing(){";
+        after += "\n    io.clientcore.core.http.exception.HttpResponseException e = new HttpResponseException();";
+        after += "\n  }";
+        after += "\n}";
+
+        rewriteRun(
+                java(before,after)
+        );
+    }
+
+    @Test
+    public void testResourceModifiedExceptionChanged() {
+        @Language("java") String before = "import com.azure.core.exception.ResourceModifiedException;";
+        before += "\npublic class Testing {";
+        before += "\n  public Testing(){";
+        before += "\n    com.azure.core.exception.ResourceModifiedException e = new ResourceModifiedException();";
+        before += "\n  }";
+        before += "\n}";
+
+        @Language("java") String after = "import com.azure.core.v2.exception.ResourceModifiedException;";
+        after += "\n\npublic class Testing {";
+        after += "\n  public Testing(){";
+        after += "\n    com.azure.core.v2.exception.ResourceModifiedException e = new ();";
+        after += "\n  }";
+        after += "\n}";
+
+        rewriteRun(
+                java(before,after)
+        );
+    }
+
+    @Test
+    public void testResourceNotFoundExceptionChanged() {
+        @Language("java") String before = "import com.azure.core.exception.ResourceNotFoundException;";
+        before += "\npublic class Testing {";
+        before += "\n  public Testing(){";
+        before += "\n    com.azure.core.exception.ResourceNotFoundException e = new ResourceNotFoundException();";
+        before += "\n  }";
+        before += "\n}";
+
+        @Language("java") String after = "import com.azure.core.v2.exception.ResourceNotFoundException;";
+        after += "\n\npublic class Testing {";
+        after += "\n  public Testing(){";
+        after += "\n    com.azure.core.v2.exception.ResourceNotFoundException e = new ResourceNotFoundException();";
+        after += "\n  }";
+        after += "\n}";
+
+        rewriteRun(
+                java(before,after)
+        );
+    }
+
+    /**
+     * Will fail and need updating if all azure-core v1 exceptions are migrated,
+     * or if all exceptions are migrated to the same directory.
+     */
+    @Test
+    public void testBundledImportsChanged() {
+        @Language("java") String before = "import com.azure.core.exception.*;";
+        before += "\npublic class Testing {";
+        before += "\n}";
+
+        @Language("java") String after = "import com.azure.core.exception.*;" +
+                "\nimport com.azure.core.v2.exception.*;" +
+                "\nio.clientcore.core.http.exception.HttpResponseException;";
+        after += "\n\npublic class Testing {";
+        after += "\n  public Testing(){";
+        after += "\n    io.clientcore.core.util.configuration.Configuration c = new Configuration();";
+        after += "\n  }";
+        after += "\n}";
+        rewriteRun(
+                java(before,after)
+        );
+    }
+}

--- a/rewrite-java-core/src/test/java/ExceptionTypesTest.java
+++ b/rewrite-java-core/src/test/java/ExceptionTypesTest.java
@@ -39,14 +39,14 @@ public class ExceptionTypesTest implements RewriteTest {
         @Language("java") String before = "import com.azure.core.exception.ClientAuthenticationException;";
         before += "\npublic class Testing {";
         before += "\n  public Testing(){";
-        before += "\n    com.azure.core.exception.ClientAuthenticationException e = new ClientAuthenticationException();";
+        before += "\n    com.azure.core.exception.ClientAuthenticationException e = new ClientAuthenticationException(null,null);";
         before += "\n  }";
         before += "\n}";
 
         @Language("java") String after = "import com.azure.core.v2.exception.ClientAuthenticationException;";
         after += "\n\npublic class Testing {";
         after += "\n  public Testing(){";
-        after += "\n    com.azure.core.v2.exception.ClientAuthenticationException e = new ClientAuthenticationException();";
+        after += "\n    com.azure.core.v2.exception.ClientAuthenticationException e = new ClientAuthenticationException(null,null);";
         after += "\n  }";
         after += "\n}";
 
@@ -60,14 +60,14 @@ public class ExceptionTypesTest implements RewriteTest {
         @Language("java") String before = "import com.azure.core.exception.HttpResponseException;";
         before += "\npublic class Testing {";
         before += "\n  public Testing(){";
-        before += "\n    com.azure.core.exception.HttpResponseException e = new HttpResponseException();";
+        before += "\n    com.azure.core.exception.HttpResponseException e = new HttpResponseException(null,null);";
         before += "\n  }";
         before += "\n}";
 
         @Language("java") String after = "import io.clientcore.core.http.exception.HttpResponseException;";
         after += "\n\npublic class Testing {";
         after += "\n  public Testing(){";
-        after += "\n    io.clientcore.core.http.exception.HttpResponseException e = new HttpResponseException();";
+        after += "\n    io.clientcore.core.http.exception.HttpResponseException e = new HttpResponseException(null,null);";
         after += "\n  }";
         after += "\n}";
 
@@ -81,14 +81,14 @@ public class ExceptionTypesTest implements RewriteTest {
         @Language("java") String before = "import com.azure.core.exception.ResourceModifiedException;";
         before += "\npublic class Testing {";
         before += "\n  public Testing(){";
-        before += "\n    com.azure.core.exception.ResourceModifiedException e = new ResourceModifiedException();";
+        before += "\n    com.azure.core.exception.ResourceModifiedException e = new ResourceModifiedException(null,null);";
         before += "\n  }";
         before += "\n}";
 
         @Language("java") String after = "import com.azure.core.v2.exception.ResourceModifiedException;";
         after += "\n\npublic class Testing {";
         after += "\n  public Testing(){";
-        after += "\n    com.azure.core.v2.exception.ResourceModifiedException e = new ();";
+        after += "\n    com.azure.core.v2.exception.ResourceModifiedException e = new ResourceModifiedException(null,null);";
         after += "\n  }";
         after += "\n}";
 
@@ -102,14 +102,14 @@ public class ExceptionTypesTest implements RewriteTest {
         @Language("java") String before = "import com.azure.core.exception.ResourceNotFoundException;";
         before += "\npublic class Testing {";
         before += "\n  public Testing(){";
-        before += "\n    com.azure.core.exception.ResourceNotFoundException e = new ResourceNotFoundException();";
+        before += "\n    com.azure.core.exception.ResourceNotFoundException e = new ResourceNotFoundException(null,null);";
         before += "\n  }";
         before += "\n}";
 
         @Language("java") String after = "import com.azure.core.v2.exception.ResourceNotFoundException;";
         after += "\n\npublic class Testing {";
         after += "\n  public Testing(){";
-        after += "\n    com.azure.core.v2.exception.ResourceNotFoundException e = new ResourceNotFoundException();";
+        after += "\n    com.azure.core.v2.exception.ResourceNotFoundException e = new ResourceNotFoundException(null,null);";
         after += "\n  }";
         after += "\n}";
 
@@ -126,14 +126,19 @@ public class ExceptionTypesTest implements RewriteTest {
     public void testBundledImportsChanged() {
         @Language("java") String before = "import com.azure.core.exception.*;";
         before += "\npublic class Testing {";
+        before += "\n  public Testing(){";
+        before += "\n    com.azure.core.exception.ClientAuthenticationException e = new ClientAuthenticationException(null,null);";
+        before += "\n    com.azure.core.exception.HttpResponseException e = new HttpResponseException(null,null);";
+        before += "\n  }";
         before += "\n}";
 
         @Language("java") String after = "import com.azure.core.exception.*;" +
-                "\nimport com.azure.core.v2.exception.*;" +
-                "\nio.clientcore.core.http.exception.HttpResponseException;";
+                "\nimport com.azure.core.v2.exception.ClientAuthenticationException;" +
+                "\nimport io.clientcore.core.http.exception.HttpResponseException;";
         after += "\n\npublic class Testing {";
         after += "\n  public Testing(){";
-        after += "\n    io.clientcore.core.util.configuration.Configuration c = new Configuration();";
+        after += "\n    com.azure.core.v2.exception.ClientAuthenticationException e = new ClientAuthenticationException(null,null);";
+        after += "\n    io.clientcore.core.http.exception.HttpResponseException e = new HttpResponseException(null,null);";
         after += "\n  }";
         after += "\n}";
         rewriteRun(


### PR DESCRIPTION
ChangeType recipes added to convert the following:
 - com.azure.core.exception.ClientAuthenticationException
 - com.azure.core.exception.HttpResponseException
 - com.azure.core.exception.ResourceModifiedException
 - com.azure.core.exception.ResourceNotFoundException
 
To:
com.azure.core.v2.exception.
 - com.azure.core.v2.exception.ClientAuthenticationException
 - com.azure.core.v2.exception.ResourceModifiedException
 - com.azure.core.v2.exception.ResourceNotFoundException
 - io.clientcore.core.http.exception.HttpResponseException

Unit tests added for all.