### PR TITLE
Added recipe to migrate ClientLogger

### DIFF
--- a/rewrite-java-core/src/main/resources/META-INF/rewrite/rewrite.yml
+++ b/rewrite-java-core/src/main/resources/META-INF/rewrite/rewrite.yml
@@ -112,7 +112,11 @@ recipeList:
       oldFullyQualifiedTypeName: com.azure.core.annotation.ReturnType
       newFullyQualifiedTypeName: com.azure.core.v2.annotation.ReturnType
 
-
+  # Recipe that changes all instances of com.azure.core.util.logging.ClientLogger
+  # to io.clientcore.core.util.ClientLogger
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: com.azure.core.util.logging.ClientLogger
+      newFullyQualifiedTypeName: io.clientcore.core.util.ClientLogger
 
   # Recipes to migrate implementations of com.azure.core.client.traits.HttpTrait
   # to io.clientcore.core.models.traits.HttpTrait

--- a/rewrite-java-core/src/test/java/ClientLoggerTest.java
+++ b/rewrite-java-core/src/test/java/ClientLoggerTest.java
@@ -1,0 +1,42 @@
+import org.intellij.lang.annotations.Language;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+public class ClientLoggerTest implements RewriteTest {
+    /**
+     * UtilConfigurationTest tests the recipe that changes
+     * com.azure.core.util.logging.ClientLogger to io.clientcore.core.util.ClientLogger.
+     * @author Ali Soltanian Fard Jahromi
+     */
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipeFromResource("/META-INF/rewrite/rewrite.yml",
+                "com.azure.rewrite.java.core.MigrateAzureCoreSamplesToAzureCoreV2");
+    }
+
+    /* Test to make sure ClientLogger type and import is changed */
+    @Test
+    public void testClientLoggerTypeAndImportChanged() {
+        @Language("java") String before = "import com.azure.core.util.logging.ClientLogger;";
+        before += "\npublic class Testing {";
+        before += "\n  public Testing(){";
+        before += "\n    com.azure.core.util.logging.ClientLogger c = new ClientLogger(Testing.class);";
+        before += "\n  }";
+        before += "\n}";
+
+        @Language("java") String after = "import io.clientcore.core.util.ClientLogger;";
+        after += "\n\npublic class Testing {";
+        after += "\n  public Testing(){";
+        after += "\n    io.clientcore.core.util.ClientLogger c = new ClientLogger(Testing.class);";
+        after += "\n  }";
+        after += "\n}";
+        rewriteRun(
+                java(before,after)
+        );
+    }
+
+}


### PR DESCRIPTION
Added recipe to convert `com.azure.core.util.logging.ClientLogger` to `io.clientcore.core.util.ClientLogger`

resolves #55 