### PR TITLE
Added before-and-after docs for Java recipes

### DIFF
--- a/rewrite-java-core/src/main/java/com/azure/recipes/core/v2/ContextRecipe.java
+++ b/rewrite-java-core/src/main/java/com/azure/recipes/core/v2/ContextRecipe.java
@@ -11,6 +11,17 @@ import org.openrewrite.java.tree.TypeTree;
 /**
  * ContextRecipe changes all instances of Context.NONE (from azure core v1) to Context.none() (from azure core v2).
  * This recipe also updates the import statements for the aforementioned class.
+ * --------------------------------------------------
+ * Before applying this recipe:
+ * import com.azure.core.util.Context;
+ * ...
+ * public void context(){ print(Context.NONE); }
+ * --------------------------------------------------
+ * After applying this recipe:
+ * import io.clientcore.core.util.Context;
+ * ...
+ * public void context(){ print(Context.none()); }
+ * --------------------------------------------------
  * @author Ali Soltanian Fard Jahromi
  */
 public class ContextRecipe extends Recipe {

--- a/rewrite-java-core/src/main/java/com/azure/recipes/core/v2/HttpLogOptionsRecipe.java
+++ b/rewrite-java-core/src/main/java/com/azure/recipes/core/v2/HttpLogOptionsRecipe.java
@@ -9,11 +9,24 @@ import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.TypeTree;
 
 /**
- * HttpLogOptionsRecipe change usage of the com.azure.core.http.policy.HttpLogDetailLevel while also changing the com.azure.core.http.policy.HttpLogOptions Type.
+ * HttpLogOptionsRecipe change usage of the com.azure.core.http.policy.HttpLogDetailLevel while also changing
+ * the com.azure.core.http.policy.HttpLogOptions Type.
  * The import statements are also updated.
  * Changes:
  * com.azure.core.http.policy.HttpLogDetailLevel -> io.clientcore.core.http.models.HttpLogOptions.HttpLogDetailLevel
  * com.azure.core.http.policy.HttpLogOptions     -> io.clientcore.core.http.models.HttpLogOptions
+ * --------------------------------------------------
+ * Before applying this recipe:
+ * import com.azure.core.http.policy.HttpLogDetailLevel;
+ * import com.azure.core.http.policy.HttpLogOptions;
+ * ...
+ * public void logOptions(){ print(new HttpLogOptions().setLogLevel(HttpLogDetailLevel.BODY_AND_HEADERS)); }
+ * --------------------------------------------------
+ * After applying this recipe:
+ * import io.clientcore.core.http.models.HttpLogOptions;
+ * ...
+ * public void logOptions(){ print(new HttpLogOptions().setLogLevel(HttpLogOptions.HttpLogDetailLevel.BODY_AND_HEADERS)); }
+ * --------------------------------------------------
  * @author Ali Soltanian Fard Jahromi
  */
 public class HttpLogOptionsRecipe extends Recipe {

--- a/rewrite-java-core/src/main/java/com/azure/recipes/core/v2/RemoveFixedDelayRecipe.java
+++ b/rewrite-java-core/src/main/java/com/azure/recipes/core/v2/RemoveFixedDelayRecipe.java
@@ -10,6 +10,12 @@ import org.openrewrite.java.tree.J;
 /**
  * RemoveFixedDelayRecipe removes any leftover imports for FixedDelayOptions
  * and any variables declared with the FixedDelayOptions type.
+ * --------------------------------------------------
+ * Removes code such as:
+ * import com.azure.core.http.policy.FixedDelayOptions;
+ * ...
+ * FixedDelayOptions s;
+ * --------------------------------------------------
  * @author Ali Soltanian Fard Jahromi
  */
 public class RemoveFixedDelayRecipe extends Recipe {
@@ -19,7 +25,7 @@ public class RemoveFixedDelayRecipe extends Recipe {
      */
     @Override
     public @NotNull String getDisplayName() {
-        return "Migrate the HttpLogOptions and HttpLogDetail usages";
+        return "Removes imports and variable declarations for FixedDelayOptions";
     }
     /**
      * Method to return a description of RemoveFixedDelayRecipe

--- a/rewrite-java-core/src/main/java/com/azure/recipes/core/v2/RetryOptionsConstructorRecipe.java
+++ b/rewrite-java-core/src/main/java/com/azure/recipes/core/v2/RetryOptionsConstructorRecipe.java
@@ -17,6 +17,17 @@ import java.util.Map;
  * RetryOptionsRecipe changes RetryOptions constructor to HttpRetryOptions constructor.
  * It also removes any references to FixedDelay and ExponentialDelay and changes
  * com.azure.core.http.policy.RetryOptions to io.clientcore.core.http.models.HttpRetryOptions
+ * --------------------------------------------------
+ * Before applying this recipe:
+ * import com.azure.core.http.policy.RetryOptions;
+ * ...
+ * new RetryOptions(new FixedDelayOptions(3, Duration.ofMillis(50)))
+ * --------------------------------------------------
+ * After applying this recipe:
+ * import io.clientcore.core.http.models.HttpRetryOptions;
+ * ...
+ * new HttpRetryOptions(3, Duration.ofMillis(50))
+ * --------------------------------------------------
  * @author Ali Soltanian Fard Jahromi
  */
 public class RetryOptionsConstructorRecipe extends Recipe {

--- a/rewrite-java-core/src/main/java/com/azure/recipes/core/v2/TypeReferenceRecipe.java
+++ b/rewrite-java-core/src/main/java/com/azure/recipes/core/v2/TypeReferenceRecipe.java
@@ -17,6 +17,33 @@ import java.util.Set;
 
 /**
  * Recipe to convert TypeReference to ParameterizedType and remove TypeReference import statements.
+ * --------------------------------------------------
+ * Before applying this recipe:
+ * import com.azure.core.util.serializer.TypeReference;
+ * ...
+ *  result = binaryDataResponse.getValue().toObject(new TypeReference<List<TranslatedTextItem>>() { });
+ * --------------------------------------------------
+ * After applying this recipe:
+ * import java.lang.reflect.ParameterizedType;
+ * import java.lang.reflect.Type;
+ * ...
+    result = binaryDataResponse.getValue().toObject(new ParameterizedType() {
+    @Override
+    public Type getRawType() {
+    return List.class;
+    }
+
+    @Override
+    public Type[] getActualTypeArguments() {
+    return new Type[]{TranslatedTextItem.class};
+    }
+
+    @Override
+    public Type getOwnerType() {
+    return null;
+    }
+    });
+ * --------------------------------------------------
  * @author Ali Soltanian Fard Jahromi
  */
 public class TypeReferenceRecipe extends Recipe {


### PR DESCRIPTION
Added before and after example code for recipe migrations for the Java-based recipes.

resolves #100 