### PR TITLE
Exclude azure library paths from recipe application

### DIFF
--- a/rewrite-java-core/src/main/java/com/azure/recipes/core/v2/AddTryCatchToMethodCallRecipe.java
+++ b/rewrite-java-core/src/main/java/com/azure/recipes/core/v2/AddTryCatchToMethodCallRecipe.java
@@ -8,13 +8,15 @@ import org.openrewrite.internal.ListUtils;
 import org.openrewrite.internal.lang.NonNull;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.JavaIsoVisitor;
-import org.openrewrite.java.JavaParser;
 import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.MethodMatcher;
-import org.openrewrite.java.tree.*;
 
 import lombok.EqualsAndHashCode;
 import lombok.Value;
+import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.MethodCall;
+import org.openrewrite.java.tree.Statement;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/rewrite-sample/pom.xml
+++ b/rewrite-sample/pom.xml
@@ -28,6 +28,10 @@
                     <activeRecipes>
                         <recipe>com.azure.rewrite.java.core.MigrateAzureCoreSamplesToAzureCoreV2</recipe>
                     </activeRecipes>
+                    <exclusions>
+                        <exclude>rewrite-sample/azure-ai-translation-text-v1/src/main/**</exclude>
+                        <exclude>rewrite-sample/azure-ai-translation-text-v2/**</exclude>
+                    </exclusions>
                 </configuration>
                 <dependencies>
                     <dependency>


### PR DESCRIPTION
Exclude the folders that include the azure libraries from being migrated by the OpenRewrite recipes, as they should only be converting the sample apps, not the libraries themselves.

resolves #121 